### PR TITLE
Gfortran+mpi for bellhop package

### DIFF
--- a/bellhop/PolyMod.F90
+++ b/bellhop/PolyMod.F90
@@ -11,7 +11,7 @@ MODULE polymod
 
   IMPLICIT NONE
   PRIVATE
-  #include "EEPARAMS_90.h"
+#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/PolyMod.F90
+++ b/bellhop/PolyMod.F90
@@ -11,7 +11,6 @@ MODULE polymod
 
   IMPLICIT NONE
   PRIVATE
-#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/Step.F90
+++ b/bellhop/Step.F90
@@ -12,7 +12,7 @@ MODULE step
 
   IMPLICIT NONE
   PRIVATE
-  #include "EEPARAMS_90.h"
+#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/Step.F90
+++ b/bellhop/Step.F90
@@ -12,7 +12,6 @@ MODULE step
 
   IMPLICIT NONE
   PRIVATE
-#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/anglemod.F90
+++ b/bellhop/anglemod.F90
@@ -14,7 +14,7 @@ MODULE anglemod
 
   IMPLICIT NONE
   PRIVATE
-  #include "EEPARAMS_90.h"
+#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/anglemod.F90
+++ b/bellhop/anglemod.F90
@@ -14,7 +14,6 @@ MODULE anglemod
 
   IMPLICIT NONE
   PRIVATE
-#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/arrMod.F90
+++ b/bellhop/arrMod.F90
@@ -11,7 +11,7 @@ MODULE arrmod
   ! Variables for arrival information
   IMPLICIT NONE
   PRIVATE
-  #include "EEPARAMS_90.h"
+#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/arrMod.F90
+++ b/bellhop/arrMod.F90
@@ -11,7 +11,6 @@ MODULE arrmod
   ! Variables for arrival information
   IMPLICIT NONE
   PRIVATE
-#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/attenmod.F90
+++ b/bellhop/attenmod.F90
@@ -13,7 +13,7 @@ MODULE attenmod
   USE fatal_error,              only: ERROUT
   IMPLICIT NONE
   PRIVATE
-  #include "EEPARAMS_90.h"
+#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/attenmod.F90
+++ b/bellhop/attenmod.F90
@@ -13,7 +13,6 @@ MODULE attenmod
   USE fatal_error,              only: ERROUT
   IMPLICIT NONE
   PRIVATE
-#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/bdryMod.F90
+++ b/bellhop/bdryMod.F90
@@ -13,7 +13,7 @@ MODULE bdrymod
 
   IMPLICIT NONE
   PRIVATE
-  #include "EEPARAMS_90.h"
+#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/bdryMod.F90
+++ b/bellhop/bdryMod.F90
@@ -13,7 +13,6 @@ MODULE bdrymod
 
   IMPLICIT NONE
   PRIVATE
-#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/beampattern.F90
+++ b/bellhop/beampattern.F90
@@ -11,7 +11,7 @@ MODULE beampattern
   USE fatal_error, only: ERROUT
   IMPLICIT NONE
   PRIVATE
-  #include "EEPARAMS_90.h"
+#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/beampattern.F90
+++ b/bellhop/beampattern.F90
@@ -11,7 +11,6 @@ MODULE beampattern
   USE fatal_error, only: ERROUT
   IMPLICIT NONE
   PRIVATE
-#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/bellhop.F90
+++ b/bellhop/bellhop.F90
@@ -52,7 +52,6 @@ MODULE BELLHOP
 
   IMPLICIT NONE
   ! PRIVATE
-#include "EEPARAMS_90.h"
   
   INTEGER              :: iostat, iAllocStat  
 

--- a/bellhop/bellhop.F90
+++ b/bellhop/bellhop.F90
@@ -52,7 +52,7 @@ MODULE BELLHOP
 
   IMPLICIT NONE
   ! PRIVATE
-  #include "EEPARAMS_90.h"
+#include "EEPARAMS_90.h"
   
   INTEGER              :: iostat, iAllocStat  
 

--- a/bellhop/bellhop_driver.F
+++ b/bellhop/bellhop_driver.F
@@ -130,7 +130,7 @@ C--
       INTEGER k, kc
 
 
-!      CALL BELLHOP_INIT
+      CALL BELLHOP_INIT
 c     INTEGER ioUnit
 c     _RS     dummyRS(1)
 !#ifdef COMPONENT_MODULE

--- a/bellhop/bellhop_driver.F
+++ b/bellhop/bellhop_driver.F
@@ -9,8 +9,8 @@ C !INTERFACE: ==========================================================
 C !DESCRIPTION:
 C Calculate ray travel times, tau
 
-C !USES: ===============================================================
-!      use bellhop
+C !FORTRAN90 USE MODULES: ===============================================
+      use bellhop
 
       IMPLICIT NONE
 #include "SIZE.h"

--- a/bellhop/bellhop_driver.F
+++ b/bellhop/bellhop_driver.F
@@ -10,16 +10,7 @@ C !DESCRIPTION:
 C Calculate ray travel times, tau
 
 C !USES: ===============================================================
-      use bellhop
-!      use lscale_cond_mod
-!      use dargan_bettsmiller_mod
-!      use surface_flux_mod
-!      use vert_turb_driver_mod
-!      use vert_diff_mod, only: gcm_vert_diff_down,
-!     &                         gcm_vert_diff_up,
-!     &                         surf_diff_type
-!      use mixed_layer_mod, only: mixed_layer
-!      use constants_mod, only:  HLv
+!      use bellhop
 
       IMPLICIT NONE
 #include "SIZE.h"
@@ -139,7 +130,7 @@ C--
       INTEGER k, kc
 
 
-      CALL BELLHOP_INIT
+!      CALL BELLHOP_INIT
 c     INTEGER ioUnit
 c     _RS     dummyRS(1)
 !#ifdef COMPONENT_MODULE

--- a/bellhop/bellhop_mod.F90
+++ b/bellhop/bellhop_mod.F90
@@ -16,7 +16,7 @@ MODULE bellhop_mod
   USE constants_mod,            only: MaxN
   IMPLICIT NONE
   PRIVATE
-  #include "EEPARAMS_90.h"
+#include "EEPARAMS_90.h"
 
   ! Reduce MaxN (= max # of steps along a ray) to reduce storage
   ! Note space is wasted in NumTopBnc, NumBotBnc ...

--- a/bellhop/bellhop_mod.F90
+++ b/bellhop/bellhop_mod.F90
@@ -16,7 +16,6 @@ MODULE bellhop_mod
   USE constants_mod,            only: MaxN
   IMPLICIT NONE
   PRIVATE
-#include "EEPARAMS_90.h"
 
   ! Reduce MaxN (= max # of steps along a ray) to reduce storage
   ! Note space is wasted in NumTopBnc, NumBotBnc ...

--- a/bellhop/constants_mod.F90
+++ b/bellhop/constants_mod.F90
@@ -43,9 +43,9 @@ MODULE constants_mod
 ! </DESCRIPTION>
 
   ! SAVE
-   implicit none
-   private
-   #include "EEPARAMS_90.h"
+  implicit none
+  private
+#include "EEPARAMS_90.h"
 
    REAL (KIND=_RL90), PUBLIC, PARAMETER :: pi = 3.1415926535898D0, &
                                            RadDeg = 180.0D0 / pi, &

--- a/bellhop/constants_mod.F90
+++ b/bellhop/constants_mod.F90
@@ -45,7 +45,6 @@ MODULE constants_mod
   ! SAVE
   implicit none
   private
-#include "EEPARAMS_90.h"
 
    REAL (KIND=_RL90), PUBLIC, PARAMETER :: pi = 3.1415926535898D0, &
                                            RadDeg = 180.0D0 / pi, &

--- a/bellhop/fatal_error.F90
+++ b/bellhop/fatal_error.F90
@@ -8,7 +8,7 @@ MODULE fatal_error
 
   IMPLICIT NONE
   INTEGER, PRIVATE :: PRTFile = 6
-  #include "EEPARAMS_90.h"
+#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/fatal_error.F90
+++ b/bellhop/fatal_error.F90
@@ -8,7 +8,6 @@ MODULE fatal_error
 
   IMPLICIT NONE
   INTEGER, PRIVATE :: PRTFile = 6
-#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/influence.F90
+++ b/bellhop/influence.F90
@@ -21,7 +21,7 @@ MODULE influence
 
   IMPLICIT NONE
   PRIVATE
-  #include "EEPARAMS_90.h"
+#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/influence.F90
+++ b/bellhop/influence.F90
@@ -21,7 +21,6 @@ MODULE influence
 
   IMPLICIT NONE
   PRIVATE
-#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/monotonic_mod.F90
+++ b/bellhop/monotonic_mod.F90
@@ -12,7 +12,6 @@ MODULE monotonic_mod
 
   IMPLICIT NONE
   PRIVATE
-#include "EEPARAMS_90.h"
   
 ! public interfaces
 !=======================================================================

--- a/bellhop/monotonic_mod.F90
+++ b/bellhop/monotonic_mod.F90
@@ -12,7 +12,7 @@ MODULE monotonic_mod
 
   IMPLICIT NONE
   PRIVATE
-  #include "EEPARAMS_90.h"
+#include "EEPARAMS_90.h"
   
 ! public interfaces
 !=======================================================================

--- a/bellhop/pchipmod.F90
+++ b/bellhop/pchipmod.F90
@@ -13,7 +13,7 @@ MODULE pchipmod
 
   IMPLICIT NONE
   PRIVATE
-  #include "EEPARAMS_90.h"
+#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/pchipmod.F90
+++ b/bellhop/pchipmod.F90
@@ -13,7 +13,6 @@ MODULE pchipmod
 
   IMPLICIT NONE
   PRIVATE
-#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/read_environment_mod.F90
+++ b/bellhop/read_environment_mod.F90
@@ -19,7 +19,6 @@ MODULE read_environment_mod
 
   IMPLICIT NONE
   PRIVATE
-#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/read_environment_mod.F90
+++ b/bellhop/read_environment_mod.F90
@@ -19,7 +19,7 @@ MODULE read_environment_mod
 
   IMPLICIT NONE
   PRIVATE
-  #include "EEPARAMS_90.h"
+#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/refCoef.F90
+++ b/bellhop/refCoef.F90
@@ -11,7 +11,6 @@ MODULE refcoef
   USE fatal_error,      only: ERROUT
   IMPLICIT NONE
   PRIVATE
-#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/refCoef.F90
+++ b/bellhop/refCoef.F90
@@ -11,7 +11,7 @@ MODULE refcoef
   USE fatal_error,      only: ERROUT
   IMPLICIT NONE
   PRIVATE
-  #include "EEPARAMS_90.h"
+#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/sourcereceiverpositions.F90
+++ b/bellhop/sourcereceiverpositions.F90
@@ -15,7 +15,7 @@ MODULE sourcereceiverpositions
 
   IMPLICIT NONE
   PRIVATE
-  #include "EEPARAMS_90.h"
+#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/sourcereceiverpositions.F90
+++ b/bellhop/sourcereceiverpositions.F90
@@ -15,7 +15,6 @@ MODULE sourcereceiverpositions
 
   IMPLICIT NONE
   PRIVATE
-#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/splinec.F90
+++ b/bellhop/splinec.F90
@@ -8,7 +8,7 @@ MODULE SPLINEC
 
 ! IMPLICIT NONE ! wish this wasn't the case
  PRIVATE
- #include "EEPARAMS_90.h"
+#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/splinec.F90
+++ b/bellhop/splinec.F90
@@ -8,7 +8,6 @@ MODULE SPLINEC
 
  IMPLICIT NONE
  PRIVATE
-#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/splinec.F90
+++ b/bellhop/splinec.F90
@@ -6,7 +6,7 @@ MODULE SPLINEC
     !   Ivana Escobar
     ! </CONTACT>
 
-! IMPLICIT NONE ! wish this wasn't the case
+ IMPLICIT NONE
  PRIVATE
 #include "EEPARAMS_90.h"
 
@@ -71,8 +71,10 @@ SUBROUTINE CSPLINE (TAU, C, N, IBCBEG, IBCEND, NDIM)
 
   ! **********************************************************************
 
-  IMPLICIT REAL (KIND=_RL90) (A-H,O-Z)
-  REAL    (KIND=_RL90) ::  TAU(N)
+  IMPLICIT INTEGER            (I-N) 
+  IMPLICIT REAL (KIND=_RL90)  (A-H,O-Z)
+  INTEGER              :: NDIM, IBCBEG, IBCEND
+  REAL    (KIND=_RL90) :: TAU(N)
   COMPLEX (KIND=_RL90) :: C(4,NDIM), G, DTAU, DIVDF1, DIVDF3
 
   L = N - 1
@@ -85,7 +87,7 @@ SUBROUTINE CSPLINE (TAU, C, N, IBCBEG, IBCEND, NDIM)
   !   * BEGINNING BOUNDARY CONDITION SECTION *
 
   IF (IBCBEG==0)  THEN                           ! IBCBEG = 0
-     IF (N.GT.2)  THEN                            !     N > 2
+     IF (N.GT.2)  THEN                           !     N > 2
         C(4,1) = C(3,3)
         C(3,1) = C(3,2) + C(3,3)
         C(2,1) = ((C(3,2) + 2.0*C(3,1))*C(4,2)*C(3,3) + &

--- a/bellhop/sspmod.F90
+++ b/bellhop/sspmod.F90
@@ -19,7 +19,7 @@ MODULE sspmod
 
   IMPLICIT NONE
   PRIVATE
-  #include "EEPARAMS_90.h"
+#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/sspmod.F90
+++ b/bellhop/sspmod.F90
@@ -19,7 +19,6 @@ MODULE sspmod
 
   IMPLICIT NONE
   PRIVATE
-#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/subtabulate.F90
+++ b/bellhop/subtabulate.F90
@@ -14,7 +14,6 @@ MODULE subtabulate
 
   IMPLICIT NONE
   PRIVATE
-#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/subtabulate.F90
+++ b/bellhop/subtabulate.F90
@@ -14,7 +14,7 @@ MODULE subtabulate
 
   IMPLICIT NONE
   PRIVATE
-  #include "EEPARAMS_90.h"
+#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/writeray.F90
+++ b/bellhop/writeray.F90
@@ -19,7 +19,7 @@ MODULE writeray
 
   IMPLICIT NONE
   PRIVATE
-  #include "EEPARAMS_90.h"
+#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================

--- a/bellhop/writeray.F90
+++ b/bellhop/writeray.F90
@@ -19,7 +19,6 @@ MODULE writeray
 
   IMPLICIT NONE
   PRIVATE
-#include "EEPARAMS_90.h"
 
 ! public interfaces
 !=======================================================================


### PR DESCRIPTION
Using `tutorial_global_oce_latlon`, I was able to compile with gnu and intel compilers using mpi. Can `use` bellhop modules in F77 files now.