### PR TITLE
bellhop READIN pass thru

### DIFF
--- a/at_2020_11_4/Bellhop/runs/MunkB_ray.env
+++ b/at_2020_11_4/Bellhop/runs/MunkB_ray.env
@@ -32,12 +32,12 @@
  5000.0  1551.91  /
 'A' 0.0             ! Bottom BC tyoe, RMS roughness
  5000.0  1800.00 0.0 2.0 / ! Bottom BC, Read by TopBot subroutine
-1				    ! NSD - Source depth
-300.0 /			    ! SD(1:NSD) (m)
-101				    ! NRD - Receiver depth
-0.0 5000.0 /		! RD(1:NRD) (m)
-1001				! NR - receiver ranges
-0.0  125.0 /		! R(1:NR ) (km)
+1				    ! NSD - Source depth, ReadVec subroutine
+300.0 /			    ! SD(1:NSD) (m), ReadVec subroutine
+101				    ! NRD - Receiver depth, ReadVec subroutine
+0.0 5000.0 /		! RD(1:NRD) (m), ReadVec subroutine
+1001				! NR - receiver ranges, ReadVec subroutine
+0.0  125.0 /		! R(1:NR ) (km), ReadVec subroutine
 'A'	  			    ! 'R/C/I/S'
 29				    ! NBeams
 -14.0 14.0 /		! ALPHA1,2 (degrees)

--- a/at_2020_11_4/Bellhop/runs/MunkB_ray.env
+++ b/at_2020_11_4/Bellhop/runs/MunkB_ray.env
@@ -2,7 +2,7 @@
 750.0			    ! FREQ (Hz)
 1			        ! NMEDIA - Can only be 1 for BELLHOP
 'PVF'			    ! SSPOPT (Analytic or C-linear interpolation)
-51  0.0  5000.0		! DEPTH of bottom (m) - 1st two numbers are not used by BELLHOP
+51  0.0  5000.0		! DEPTH of bottom (m) - 1st two numbers are not used by BELLHOP read by TopBot subroutine
     0.0  1548.52  /
   200.0  1530.29  /
   250.0  1526.69  /
@@ -30,8 +30,8 @@
  4600.0  1545.14  /
  4800.0  1548.52  /
  5000.0  1551.91  /
-'A' 0.0
- 5000.0  1800.00 0.0 2.0 /
+'A' 0.0             ! Bottom BC tyoe, RMS roughness
+ 5000.0  1800.00 0.0 2.0 / ! Bottom BC, Read by TopBot subroutine
 1				    ! NSD - Source depth
 300.0 /			    ! SD(1:NSD) (m)
 101				    ! NRD - Receiver depth

--- a/at_2020_11_4/Bellhop/runs/MunkB_ray.env
+++ b/at_2020_11_4/Bellhop/runs/MunkB_ray.env
@@ -1,6 +1,6 @@
 'Munk profile'		! TITLE
 750.0			    ! FREQ (Hz)
-1			        ! NMEDIA - compatibility with other AT programs
+1			        ! NMEDIA - Can only be 1 for BELLHOP
 'PVF'			    ! SSPOPT (Analytic or C-linear interpolation)
 51  0.0  5000.0		! DEPTH of bottom (m) - 1st two numbers are not used by BELLHOP
     0.0  1548.52  /

--- a/at_2020_11_4/Bellhop/runs/MunkB_ray.env
+++ b/at_2020_11_4/Bellhop/runs/MunkB_ray.env
@@ -40,5 +40,5 @@
 0.0  125.0 /		! R(1:NR ) (km), ReadVec subroutine
 'A'	  			    ! 'A/R/C/I/S', Beam run type
 29				    ! NBeams, ReadRayElevationAngles subroutine
--14.0 14.0 /		! ALPHA1,2 (degrees), ReadRayElevationAngles subroutine
+-14.0 14.0 /		! ALPHA1,2 (degrees), ReadRayElevationAngles subroutine, +ve is pointing to ocean bottom
 0.0  5500.0 124.9	! STEP (m), ZBOX (m), RBOX (km)

--- a/at_2020_11_4/Bellhop/runs/MunkB_ray.env
+++ b/at_2020_11_4/Bellhop/runs/MunkB_ray.env
@@ -38,7 +38,7 @@
 0.0 5000.0 /		! RD(1:NRD) (m), ReadVec subroutine
 1001				! NR - receiver ranges, ReadVec subroutine
 0.0  125.0 /		! R(1:NR ) (km), ReadVec subroutine
-'A'	  			    ! 'R/C/I/S'
-29				    ! NBeams
--14.0 14.0 /		! ALPHA1,2 (degrees)
+'A'	  			    ! 'A/R/C/I/S', Beam run type
+29				    ! NBeams, ReadRayElevationAngles subroutine
+-14.0 14.0 /		! ALPHA1,2 (degrees), ReadRayElevationAngles subroutine
 0.0  5500.0 124.9	! STEP (m), ZBOX (m), RBOX (km)

--- a/bellhop/anglemod.F90
+++ b/bellhop/anglemod.F90
@@ -27,9 +27,10 @@ MODULE anglemod
   REAL (KIND=_RL90), PRIVATE, PARAMETER :: c0 = 1500.0
 
   TYPE AnglesStructure
-     INTEGER       :: Nalpha = 0, Nbeta = 1, iSingle_alpha = 0, iSingle_beta = 0
-     REAL (KIND=_RL90) :: Dalpha, Dbeta
-     REAL (KIND=_RL90), ALLOCATABLE:: alpha( : ), beta( : )
+     INTEGER                        :: Nalpha = 0, Nbeta = 1, &
+                                       iSingle_alpha = 0, iSingle_beta = 0
+     REAL (KIND=_RL90)              :: Dalpha, Dbeta
+     REAL (KIND=_RL90), ALLOCATABLE :: alpha( : ), beta( : )
   END TYPE AnglesStructure
 
   Type( AnglesStructure ) :: Angles
@@ -37,12 +38,11 @@ MODULE anglemod
 CONTAINS
   SUBROUTINE ReadRayElevationAngles( freq, Depth, TopOpt, RunType )
 
-    REAL (KIND=_RL90), INTENT( IN  ) :: freq, Depth
+    REAL (KIND=_RL90),  INTENT( IN  ) :: freq, Depth
     CHARACTER (LEN= 6), INTENT( IN  ) :: TopOpt, RunType
-    REAL (KIND=_RL90)                :: d_theta_recommended
+    REAL (KIND=_RL90)   :: d_theta_recommended
 
-    IF ( TopOpt( 6 : 6 ) == 'I' ) THEN
-       ! option to trace a single beam
+    IF ( TopOpt( 6 : 6 ) == 'I' ) THEN ! option to trace a single beam
        READ( ENVFile, * ) Angles%Nalpha, Angles%iSingle_alpha 
     ELSE
        READ( ENVFile, * ) Angles%Nalpha
@@ -81,7 +81,8 @@ CONTAINS
                     Angles%alpha( 1 ), 360.0D0 ) ) < 10.0 * TINY( 1.0D0 ) ) &
                     Angles%Nalpha = Angles%Nalpha - 1
 
-    WRITE( PRTFile, * ) '__________________________________________________________________________'
+    WRITE( PRTFile, * ) '_________________________________________________', &
+                        '_________________________'
     WRITE( PRTFile, * )
     WRITE( PRTFile, * ) 'Number of beams in elevation   = ', Angles%Nalpha
     IF ( Angles%iSingle_alpha > 0 ) WRITE( PRTFile, * ) &
@@ -146,13 +147,14 @@ CONTAINS
     ! Nx2D CASE: beams must lie on rcvr radials--- replace beta with theta
     IF ( RunType( 6 : 6 ) == '2' .AND. RunType( 1 : 1 ) /= 'R' ) THEN
        WRITE( PRTFile, * )
-       WRITE( PRTFile, * ) 'Replacing beam take-off angles, beta, with receiver bearing lines, theta'
+       WRITE( PRTFile, * ) 'Replacing beam take-off angles, beta, with ', &
+                           'receiver bearing lines, theta'
        DEALLOCATE( Angles%beta )
 
        Angles%Nbeta = Pos%Ntheta
        ALLOCATE( Angles%beta( MAX( 3, Angles%Nbeta ) ), STAT = iAllocStat )
        IF ( iAllocStat /= 0 ) CALL ERROUT( 'ReadRayBearingAngles', &
-                                    'Insufficient memory to store beam angles'  )
+                                    'Insufficient memory to store beam angles')
        ! Nbeta should = Ntheta
        Angles%beta( 1 : Angles%Nbeta ) = Pos%theta( 1 : Pos%Ntheta )  
     END IF

--- a/bellhop/attenmod.F90
+++ b/bellhop/attenmod.F90
@@ -132,7 +132,7 @@ CONTAINS
 
     ! Convert Nepers/m to equivalent imaginary sound speed 
     alphaT = alphaT * c * c / omega
-    CRCI   = CMPLX( c, alphaT, KIND=8 )
+    CRCI   = CMPLX( c, alphaT, KIND=_RL90 )
 
     IF ( alphaT > c ) THEN
        WRITE( PRTFile, * ) 'Complex sound speed: ', CRCI

--- a/bellhop/attenmod.F90
+++ b/bellhop/attenmod.F90
@@ -65,10 +65,10 @@ CONTAINS
 
     USE constants_mod,    only: pi
 
-    REAL (KIND=_RL90), INTENT( IN )  :: freq, freq0, alpha, c, z, beta, fT
-    CHARACTER (LEN=2), INTENT( IN )  :: AttenUnit
-    REAL (KIND=_RL90)                :: f2, omega, alphaT, Thorp, a, FG
-    COMPLEX  (KIND=_RL90)                :: CRCI
+    REAL (KIND=_RL90), INTENT( IN ) :: freq, freq0, alpha, c, z, beta, fT
+    CHARACTER (LEN=2), INTENT( IN ) :: AttenUnit
+    REAL    (KIND=_RL90)            :: f2, omega, alphaT, Thorp, a, FG
+    COMPLEX (KIND=_RL90)            :: CRCI
 
     omega = 2.0 * pi * freq
 

--- a/bellhop/bdryMod.F90
+++ b/bellhop/bdryMod.F90
@@ -35,7 +35,7 @@ MODULE bdrymod
   ! Halfspace properties
   TYPE HSInfo2
      ! compressional and shear wave speeds/attenuations in user units
-     REAL (KIND=_RL90) :: alphaR, alphaI, betaR, betaI  
+     REAL     (KIND=_RL90) :: alphaR, alphaI, betaR, betaI  
      COMPLEX  (KIND=_RL90) :: cP, cS    ! P-wave, S-wave speeds
      REAL (KIND=_RL90) :: rho, Depth    ! density, depth
      CHARACTER (LEN=1) :: BC            ! Boundary condition type
@@ -66,7 +66,8 @@ CONTAINS
 
     SELECT CASE ( TopATI )
     CASE ( '~', '*' )
-       WRITE( PRTFile, * ) '__________________________________________________________________________'
+       WRITE( PRTFile, * ) '______________________________________________', &
+                           '____________________________'
        WRITE( PRTFile, * )
        WRITE( PRTFile, * ) 'Using top-altimetry file'
 
@@ -106,14 +107,14 @@ CONTAINS
           SELECT CASE ( atiType( 2 : 2 ) )
           CASE ( 'S', '' )
              READ(  ATIFile, * ) Top( ii )%x
-             IF ( ii < Number_to_Echo .OR. ii == NatiPts ) THEN   ! echo some values
+             IF ( ii < Number_to_Echo .OR. ii == NatiPts ) THEN   
                 WRITE( PRTFile, FMT = "(2G11.3)" ) Top( ii )%x
              END IF
           CASE ( 'L' )
              READ(  ATIFile, * ) Top( ii )%x, Top( ii )%HS%alphaR, &
                                  Top( ii )%HS%betaR, Top( ii )%HS%rho, &
                                  Top( ii )%HS%alphaI, Top( ii )%HS%betaI
-             IF ( ii < Number_to_Echo .OR. ii == NatiPts ) THEN   ! echo some values
+             IF ( ii < Number_to_Echo .OR. ii == NatiPts ) THEN   
                 WRITE( PRTFile, FMT = "(7G11.3)" ) &
                     Top( ii )%x, Top( ii )%HS%alphaR, Top( ii )%HS%betaR, &
                     Top( ii )%HS%rho, Top( ii )%HS%alphaI, Top( ii )%HS%betaI
@@ -158,12 +159,13 @@ CONTAINS
 
     INTEGER,            INTENT( IN ) :: PRTFile
     CHARACTER (LEN= 1), INTENT( IN ) :: BotBTY
-    REAL (KIND=_RL90), INTENT( IN ) :: DepthB
+    REAL (KIND=_RL90),  INTENT( IN ) :: DepthB
     CHARACTER (LEN=80), INTENT( IN ) :: FileRoot
 
     SELECT CASE ( BotBTY )
     CASE ( '~', '*' )
-       WRITE( PRTFile, * ) '__________________________________________________________________________'
+       WRITE( PRTFile, * ) '________________________________________________', &
+                           '__________________________'
        WRITE( PRTFile, * )
        WRITE( PRTFile, * ) 'Using bottom-bathymetry file'
 
@@ -215,14 +217,14 @@ CONTAINS
           SELECT CASE ( btyType( 2 : 2 ) )
           CASE ( 'S', '' )   ! short format
              READ(  BTYFile, * ) Bot( ii )%x
-             IF ( ii < Number_to_Echo .OR. ii == NbtyPts ) THEN  ! echo some values
+             IF ( ii < Number_to_Echo .OR. ii == NbtyPts ) THEN  
                 WRITE( PRTFile, FMT = "(2G11.3)" ) Bot( ii )%x
              END IF
           CASE ( 'L' )       ! long format
              READ(  BTYFile, * ) Bot( ii )%x, Bot( ii )%HS%alphaR, &
                                  Bot( ii )%HS%betaR, Bot( ii )%HS%rho, &
                                  Bot( ii )%HS%alphaI, Bot( ii )%HS%betaI
-             IF ( ii < Number_to_Echo .OR. ii == NbtyPts ) THEN   ! echo some values
+             IF ( ii < Number_to_Echo .OR. ii == NbtyPts ) THEN   
                 WRITE( PRTFile, FMT="( F10.2, F10.2, 3X, 2F10.2, 3X, F6.2, 3X, 2F10.4 )" ) &
                    Bot( ii )%x, Bot( ii )%HS%alphaR, Bot( ii )%HS%betaR, &
                    Bot( ii )%HS%rho, Bot( ii )%HS%alphaI, Bot( ii )%HS%betaI

--- a/bellhop/bellhop.F90
+++ b/bellhop/bellhop.F90
@@ -163,7 +163,8 @@ SUBROUTINE BELLHOP_INIT
      SrcBmPat( 1, : ) = [ -180.0, 0.0 ]
      SrcBmPat( 2, : ) = [  180.0, 0.0 ]
      SrcBmPat( :, 2 ) = 10**( SrcBmPat( :, 2 ) / 20 )  ! convert dB to linear scale
-  ELSE
+  ELSE ! Read and allocate user input 
+     ! Read .env file
      CALL ReadEnvironment(  FileRoot, ThreeD )
      ! AlTImetry
      CALL ReadATI( FileRoot, Bdry%Top%HS%Opt( 5:5 ), Bdry%Top%HS%Depth, PRTFile )

--- a/bellhop/bellhop.F90
+++ b/bellhop/bellhop.F90
@@ -23,7 +23,7 @@ MODULE BELLHOP
   ! First version (1983) originally developed with Homer Bucker, Naval Ocean 
   ! Systems Center
   
-  USE bellhop_mod ! Added to get title, freq, Beam
+  USE bellhop_mod               ! Added to get title, freq, Beam
   USE constants_mod,            only: pi, i, DegRad, RadDeg, PRTFile, SHDFile,&
                                       ARRFile, RAYFile, MaxN
   USE read_Environment_mod,     only: ReadEnvironment, ReadTopOpt, ReadRunType,&

--- a/bellhop/bellhop_mod.F90
+++ b/bellhop/bellhop_mod.F90
@@ -43,7 +43,7 @@ MODULE bellhop_mod
   TYPE BeamStructure
      INTEGER           :: NBeams, Nimage, Nsteps, iBeamWindow
      REAL (KIND=_RL90) :: deltas, epsMultiplier = 1, rLoop
-     CHARACTER (LEN=1) :: Component              ! Pressure or displacement
+     CHARACTER (LEN=1) :: Component ! Pressure or displacement
      CHARACTER (LEN=4) :: Type = 'G S '
      CHARACTER (LEN=7) :: RunType
      TYPE( rxyz )      :: Box

--- a/bellhop/constants_mod.F90
+++ b/bellhop/constants_mod.F90
@@ -54,6 +54,7 @@ MODULE constants_mod
    INTEGER, PUBLIC, PARAMETER :: ENVFile = 5, PRTFile = 6, RAYFile = 21, &
                                  SHDFile = 25, ARRFile = 36, SSPFile = 40, &
                                  MaxN = 10000
+    ! NOTE: SSPFile and ATIFile are both set to 40.... seems wrong for now
   ! Reduce MaxN (= max # of steps along a ray) to reduce storage
   ! Note space is wasted in NumTopBnc, NumBotBnc ...
 

--- a/bellhop/pchipmod.F90
+++ b/bellhop/pchipmod.F90
@@ -45,12 +45,12 @@ CONTAINS
     ! csWork is a temporary work space for the cubic spline
 
     INTEGER,              INTENT( IN  )   :: N
-    REAL (KIND=_RL90),    INTENT( IN  )   :: x( * )
+    REAL    (KIND=_RL90), INTENT( IN  )   :: x( * )
     COMPLEX (KIND=_RL90), INTENT( IN  )   :: y( * )
     COMPLEX (KIND=_RL90), INTENT( INOUT ) :: PolyCoef( 4, * ), csWork( 4, * )
 
     INTEGER               :: ix, iBCBeg, iBCEnd
-    REAL (KIND=_RL90)     :: h1, h2
+    REAL     (KIND=_RL90) :: h1, h2
     COMPLEX  (KIND=_RL90) :: del1, del2, f1, f2, f1prime, f2prime, fprimeT
 
     !  Precompute estimates of the derivatives at the nodes

--- a/bellhop/read_environment_mod.F90
+++ b/bellhop/read_environment_mod.F90
@@ -106,10 +106,10 @@ CONTAINS
     ENDIF
 
     Bdry%Top%HS%Depth = SSP%z( 1 )   ! Depth of top boundary is taken from 
-    !first SSP point
-    ! bottom depth should perhaps be set the same way?
+    ! first SSP point
 
     ! *** Bottom BC ***
+    ! bottom depth should perhaps be set the same way?
     Bdry%Bot%HS%Opt = '  '   ! initialize to blanks
     READ(  ENVFile, * ) Bdry%Bot%HS%Opt, Sigma
     WRITE( PRTFile, * )
@@ -129,9 +129,9 @@ CONTAINS
     ! *** source and receiver locations ***
 
     CALL ReadSxSy( ThreeD )     ! Read source/receiver x-y coordinates
-
     ZMin = SNGL( Bdry%Top%HS%Depth )
     ZMax = SNGL( Bdry%Bot%HS%Depth )
+
     CALL ReadSzRz( ZMin, ZMax )
     CALL ReadRcvrRanges
     IF ( ThreeD ) CALL ReadRcvrBearings

--- a/bellhop/read_environment_mod.F90
+++ b/bellhop/read_environment_mod.F90
@@ -140,14 +140,14 @@ CONTAINS
 
     Depth = Zmax - Zmin   ! water depth
     CALL ReadRayElevationAngles( freq, Depth, Bdry%Top%HS%Opt, Beam%RunType )
-    IF ( ThreeD ) CALL ReadRayBearingAngles(   freq, Bdry%Top%HS%Opt, Beam%RunType )
+    IF ( ThreeD ) CALL ReadRayBearingAngles( freq, Bdry%Top%HS%Opt, Beam%RunType )
 
     WRITE( PRTFile, * )
-    WRITE( PRTFile, * ) '__________________________________________________________________________'
+    WRITE( PRTFile, * ) '___________________________________________________', &
+                        '_______________________'
     WRITE( PRTFile, * )
 
     ! Limits for tracing beams
-
     IF ( ThreeD ) THEN
        READ(  ENVFile, * ) Beam%deltas, Beam%Box%x, Beam%Box%y, Beam%Box%z
        Beam%Box%x = 1000.0 * Beam%Box%x   ! convert km to m
@@ -393,8 +393,7 @@ CONTAINS
 
   SUBROUTINE ReadRunType( RunType, PlotType )
 
-    ! Read the RunType variable and echo with explanatory information to the 
-    ! print file
+    ! Read the RunType variable and print to .prt file
 
     USE sourcereceiverpositions, only: Pos
 

--- a/bellhop/read_environment_mod.F90
+++ b/bellhop/read_environment_mod.F90
@@ -487,7 +487,7 @@ CONTAINS
 
     REAL (KIND=_RL90), INTENT( IN    ) :: freq  ! frequency
     CHARACTER (LEN=2), INTENT( IN    ) :: AttenUnit
-    TYPE( HSInfo ),    INTENT( INOUT ) :: HS
+    TYPE ( HSInfo ),   INTENT( INOUT ) :: HS
     REAL (KIND=_RL90) :: Mz, vr, alpha2_f     ! values related to grain size
 
     ! Echo to PRTFile user's choice of boundary condition

--- a/bellhop/read_environment_mod.F90
+++ b/bellhop/read_environment_mod.F90
@@ -279,7 +279,7 @@ CONTAINS
     CHARACTER (LEN=80), INTENT( IN  ) :: FileRoot
     INTEGER            :: iostat
 
-    TopOpt = '      '   ! initialize to blanks
+    TopOpt = '      '   ! initialize to 6 blank spaces
     READ(  ENVFile, * ) TopOpt
     WRITE( PRTFile, * )
 
@@ -485,7 +485,7 @@ CONTAINS
 
     ! Handles top and bottom boundary conditions
 
-    REAL (KIND=_RL90), INTENT( IN    ) :: freq               ! frequency
+    REAL (KIND=_RL90), INTENT( IN    ) :: freq  ! frequency
     CHARACTER (LEN=2), INTENT( IN    ) :: AttenUnit
     TYPE( HSInfo ),    INTENT( INOUT ) :: HS
     REAL (KIND=_RL90) :: Mz, vr, alpha2_f     ! values related to grain size
@@ -494,7 +494,7 @@ CONTAINS
 
     SELECT CASE ( HS%BC )
     CASE ( 'V' )
-       WRITE( PRTFile, * ) '    VACUUM'
+       WRITE( PRTFile, * ) '    Surface modeled as a VACUUM'
     CASE ( 'R' )
        WRITE( PRTFile, * ) '    Perfectly RIGID'
     CASE ( 'A' )

--- a/bellhop/refCoef.F90
+++ b/bellhop/refCoef.F90
@@ -18,10 +18,10 @@ MODULE refcoef
            ReflectionCoef, RBot, RTop, NBotPts, NTopPts
 !=======================================================================
 
-  INTEGER, PARAMETER            :: BRCFile = 31, TRCFile = 32, IRCFile = 12
-  INTEGER                       :: NBotPts, NTopPts
-  INTEGER                       :: NkTab
-  INTEGER,          ALLOCATABLE :: iTab( : )
+  INTEGER, PARAMETER    :: BRCFile = 31, TRCFile = 32, IRCFile = 12
+  INTEGER               :: NBotPts, NTopPts
+  INTEGER               :: NkTab
+  INTEGER,              ALLOCATABLE :: iTab( : )
   REAL    (KIND=_RL90), ALLOCATABLE :: xTab( : )
   COMPLEX (KIND=_RL90), ALLOCATABLE :: fTab( : ), gTab( : )
 
@@ -46,7 +46,8 @@ CONTAINS
     CHARACTER (LEN=80) :: Title2
 
     IF ( BotRC == 'F' ) THEN
-       WRITE( PRTFile, * ) '__________________________________________________________________________'
+       WRITE( PRTFile, * ) '_______________________________________________', &
+                           '___________________________'
        WRITE( PRTFile, * )
        WRITE( PRTFile, * ) 'Using tabulated bottom reflection coef.'
        OPEN( FilE = TRIM( FileRoot ) // '.brc', UNIT = BRCFile, STATUS = 'OLD',&
@@ -78,7 +79,8 @@ CONTAINS
     ! Optionally read in top reflection coefficient
 
     IF ( TopRC == 'F' ) THEN
-       WRITE( PRTFile, * ) '__________________________________________________________________________'
+       WRITE( PRTFile, * ) '_______________________________________________', &
+                           '___________________________'
        WRITE( PRTFile, * )
        WRITE( PRTFile, * ) 'Using tabulated top    reflection coef.'
        OPEN( FILE = TRIM( FileRoot ) // '.trc', UNIT = TRCFile, STATUS = 'OLD',&

--- a/bellhop/sspmod.F90
+++ b/bellhop/sspmod.F90
@@ -43,13 +43,13 @@ MODULE sspmod
 
   ! SSP
   TYPE SSPStructure
-    INTEGER              :: NPts, Nr, Nx, Ny, Nz
-    REAL (KIND=_RL90)                  :: z( MaxSSP ), rho( MaxSSP )
-    COMPLEX (KIND=_RL90)     :: c( MaxSSP ), cz( MaxSSP ), n2( MaxSSP ), &
-                            n2z( MaxSSP ), cSpline( 4, MaxSSP )
-    COMPLEX (KIND=_RL90)     :: cCoef( 4, MaxSSP ), CSWork( 4, MaxSSP )   ! for PCHIP coefs.
-    REAL (KIND=_RL90), ALLOCATABLE     :: cMat( :, : ), czMat( :, : ), cMat3( :, :, : ), & 
-                            czMat3( :, :, : )
+    INTEGER                 :: NPts, Nr, Nx, Ny, Nz
+    REAL    (KIND=_RL90)    :: z( MaxSSP ), rho( MaxSSP )
+    COMPLEX (KIND=_RL90)    :: c( MaxSSP ), cz( MaxSSP ), n2( MaxSSP ), &
+                               n2z( MaxSSP ), cSpline( 4, MaxSSP )
+    COMPLEX (KIND=_RL90)    :: cCoef( 4, MaxSSP ), CSWork( 4, MaxSSP )   ! for PCHIP coefs.
+    REAL    (KIND=_RL90), ALLOCATABLE   :: cMat( :, : ),     czMat( :, : ), &
+                                           cMat3( :, :, : ), czMat3( :, :, : )
     TYPE ( rxyz_vector ) :: Seg
     CHARACTER (LEN=1)    :: Type
     CHARACTER (LEN=2)    :: AttenUnit
@@ -60,11 +60,11 @@ MODULE sspmod
   ! *** Halfspace properties structure ***
 
   TYPE HSInfo
-     REAL (KIND=_RL90) :: alphaR, alphaI, betaR, betaI    ! compressional and shear wave speeds/attenuations in user units
-     COMPLEX  (KIND=_RL90) :: cP, cS            ! P-wave, S-wave speeds
-     REAL (KIND=_RL90)               :: rho, Depth        ! density, depth
-     CHARACTER (LEN=1) :: BC                ! Boundary condition type
-     CHARACTER (LEN=6) :: Opt
+     REAL   (KIND=_RL90)    :: alphaR, alphaI, betaR, betaI    ! compressional and shear wave speeds/attenuations in user units
+     COMPLEX(KIND=_RL90)    :: cP, cS            ! P-wave, S-wave speeds
+     REAL   (KIND=_RL90)    :: rho, Depth        ! density, depth
+     CHARACTER (LEN=1)      :: BC                ! Boundary condition type
+     CHARACTER (LEN=6)      :: Opt
   END TYPE HSInfo
 
   TYPE BdryPt

--- a/bellhop/subtabulate.F90
+++ b/bellhop/subtabulate.F90
@@ -9,6 +9,7 @@ MODULE subtabulate
   ! If x(3) = -999.9 then subtabulation is performed
   ! i.e., a vector is generated with Nx points in [ x(1), x(2) ]
   ! If x(2) = -999.9 then x(1) is repeated into x(2)
+  ! tabulates info in outputfile
 
   ! mbp 1/2015
 
@@ -47,9 +48,9 @@ CONTAINS
 
   SUBROUTINE SubTab_dble( x, Nx )
 
-    INTEGER,       INTENT( IN )    :: Nx
-    REAL (KIND=_RL90), INTENT( INOUT ) :: x( Nx )
-    REAL (KIND=_RL90)                  :: deltax
+    INTEGER,            INTENT( IN    ) :: Nx
+    REAL (KIND=_RL90),  INTENT( INOUT ) :: x( Nx )
+    REAL (KIND=_RL90)   :: deltax
 
     IF ( Nx >= 3 ) THEN
        IF ( x( 3 ) == -999.9 ) THEN   ! testing for equality here is dangerous


### PR DESCRIPTION
Create and populate `Bdry`, `SSP`, `Pos`, `Beam`, `Angles` FORTRAN structures

Understand reading through **.env** file, and writing given information to **.prt** and other output files. Had to resist rewriting formatting, and how rigid the reading routine is, there are no defensive checks for reading file in the wrong order! 

Formatted files to try to stay readable, which was difficult since the code mixes spaces and tabulation. 

Learned the code does allow for broadband sources, instead of only a fixed frequency. The code also allows for custom reflection coefficients and bathymetry. 

Potential issue in SSPFile and ATIFile sharing the same integer value `SSPFile = 40`. Won't worry about it until I need to specify altimetry as input. 