### PR TITLE
MPI enables I/O

### DIFF
--- a/fortran/.gitignore
+++ b/fortran/.gitignore
@@ -2,5 +2,6 @@ testme
 make_readnetcdf
 
 
+*.f90
 *.f
 *.o

--- a/fortran/make_vectorPassMPI
+++ b/fortran/make_vectorPassMPI
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cat vectorPass.F90 | cpp -traditional -P -I${MPI_DIR}/include > vectorPass.f90
+ifort -o vectorpassMPI.exe vectorPass.f90 -g -I${MPI_DIR}/lib -Wl,-rpath -Wl,${MPI_DIR}/lib -L${MPI_DIR}/lib -lmpi_usempif08 -lmpi_mpifh -lmpi

--- a/fortran/vectorPass.F90
+++ b/fortran/vectorPass.F90
@@ -1,0 +1,41 @@
+PROGRAM vectorPass
+    use mpi
+    implicit none
+
+    integer :: myThid, num_procs, n, i, tag
+    integer, parameter :: n_elements=20
+    real(8) :: vectorA(n_elements), vectorB(n_elements), vectorOut(n_elements)
+    integer :: ierr, status(MPI_STATUS_SIZE)
+
+    call MPI_INIT(ierr)
+    call MPI_COMM_RANK( MPI_COMM_WORLD, myThid, ierr )
+    call MPI_COMM_SIZE( MPI_COMM_WORLD, num_procs, ierr )
+
+    do i = 1, n_elements
+        vectorA(i) = i * 1.0
+        vectorB(i) = i * 10.0
+    enddo
+
+    do i = 1, n_elements
+        vectorOut(i) = vectorA(i) + vectorB(i)
+    enddo
+
+    do n = 1,num_procs
+        print *, "myThid = ", n
+        do i = 1,n_elements
+            print *, vectorOut(i)
+        enddo
+    enddo
+
+    call MPI_BARRIER( MPI_COMM_WORLD, ierr )
+
+    if (myThid == 0) then
+        print *, "vector out:" 
+        do i = 1,n_elements
+            print *, vectorOut(i)
+        enddo
+    endif
+
+    call MPI_FINALIZE(ierr)
+
+END PROGRAM vectorPass

--- a/ihop/angle_mod.F90
+++ b/ihop/angle_mod.F90
@@ -45,7 +45,13 @@ MODULE angle_mod
 CONTAINS
   SUBROUTINE ReadRayElevationAngles( freq, Depth, TopOpt, RunType, myThid )
 
-    INTEGER, INTENT( IN ) :: myThid
+  !     == Routine Arguments ==
+  !     myThid :: Thread number. Unused by IESCO
+  !     msgBuf :: Used to build messages for printing.
+    INTEGER, INTENT( IN )   :: myThid
+    CHARACTER*(MAX_LEN_MBUF):: msgBuf
+  
+  !     == Local Variables ==
     REAL (KIND=_RL90),  INTENT( IN  ) :: freq, Depth
     CHARACTER (LEN= 6), INTENT( IN  ) :: TopOpt, RunType
     REAL (KIND=_RL90)   :: d_theta_recommended
@@ -95,18 +101,28 @@ CONTAINS
                     Angles%Nalpha = Angles%Nalpha - 1
 
 #ifdef IHOP_WRITE_OUT
-    WRITE( PRTFile, * ) '_________________________________________________', &
-                        '_________________________'
-    WRITE( PRTFile, * )
-    WRITE( PRTFile, * ) 'Number of beams in elevation   = ', Angles%Nalpha
-    IF ( Angles%iSingle_alpha > 0 ) WRITE( PRTFile, * ) &
-                                'Trace only beam number ', Angles%iSingle_alpha
-    WRITE( PRTFile, * ) 'Beam take-off angles (degrees)'
+    WRITE(msgBuf,'(2A)')'_________________________________________________', &
+                        '__________'
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    WRITE(msgBuf,'(A)')
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    WRITE(msgBuf,'(A,I)') 'Number of beams in elevation   = ', Angles%Nalpha
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    IF ( Angles%iSingle_alpha > 0 ) THEN
+        WRITE(msgBuf,'(A,I)') 'Trace only beam number ', Angles%iSingle_alpha
+        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    END IF
+    WRITE(msgBuf,'(A)') 'Beam take-off angles (degrees)'
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 
-    IF ( Angles%Nalpha >= 1 ) WRITE( PRTFile, "( 5G14.6 )" ) &
-                        Angles%alpha( 1 : MIN( Angles%Nalpha, Number_to_Echo ) )
-    IF ( Angles%Nalpha > Number_to_Echo ) WRITE( PRTFile,  "( G14.6 )" ) &
-                                        ' ... ', Angles%alpha( Angles%Nalpha )
+    IF ( Angles%Nalpha >= 1 ) THEN
+        WRITE(msgBuf,'(5G14.6)') Angles%alpha( 1:MIN(Angles%Nalpha,Number_to_Echo) )
+        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    END IF
+    IF ( Angles%Nalpha > Number_to_Echo ) THEN
+        WRITE(msgBuf,'(G14.6)') ' ... ', Angles%alpha( Angles%Nalpha )
+        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    END IF
 #endif /* IHOP_WRITE_OUT */
 
     IF ( Angles%Nalpha>1 .AND. &
@@ -136,7 +152,13 @@ CONTAINS
 
   SUBROUTINE ReadRayBearingAngles( freq, TopOpt, RunType, myThid )
 
-    INTEGER, INTENT( IN ) :: myThid
+  !     == Routine Arguments ==
+  !     myThid :: Thread number. Unused by IESCO
+  !     msgBuf :: Used to build messages for printing.
+    INTEGER, INTENT( IN )   :: myThid
+    CHARACTER*(MAX_LEN_MBUF):: msgBuf
+  
+  !     == Local Variables ==
     REAL (KIND=_RL90), INTENT( IN ) :: freq
     CHARACTER (LEN= 6), INTENT( IN ) :: TopOpt, RunType
 
@@ -185,9 +207,11 @@ CONTAINS
     ! Nx2D CASE: beams must lie on rcvr radials--- replace beta with theta
     IF ( RunType( 6 : 6 ) == '2' .AND. RunType( 1 : 1 ) /= 'R' ) THEN
 #ifdef IHOP_WRITE_OUT
-       WRITE( PRTFile, * )
-       WRITE( PRTFile, * ) 'Replacing beam take-off angles, beta, with ', &
+       WRITE(msgBuf,'(A)')
+       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+       WRITE(msgBuf,'(A)') 'Replacing beam take-off angles, beta, with ', &
                            'receiver bearing lines, theta'
+       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
        DEALLOCATE( Angles%beta )
 
@@ -206,16 +230,25 @@ CONTAINS
     END IF
 
 #ifdef IHOP_WRITE_OUT
-    WRITE( PRTFile, * )
-    WRITE( PRTFile, * ) 'Number of beams in bearing   = ', Angles%Nbeta
-    IF ( Angles%iSingle_beta > 0 ) WRITE( PRTFile, * ) &
-                                'Trace only beam number ', Angles%iSingle_beta
-    WRITE( PRTFile, * ) 'Beam take-off angles (degrees)'
+    WRITE(msgBuf,'(A)')
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    WRITE(msgBuf,'(A,I)') 'Number of beams in bearing   = ', Angles%Nbeta
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    IF ( Angles%iSingle_beta > 0 ) THEN
+        WRITE(msgBuf,'(A,I)') 'Trace only beam number ', Angles%iSingle_beta
+        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    END IF
+    WRITE(msgBuf,'(A)') 'Beam take-off angles (degrees)'
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 
-    IF ( Angles%Nbeta >= 1 ) WRITE( PRTFile, "( 5G14.6 )" ) &
-                        Angles%beta( 1 : MIN( Angles%Nbeta, Number_to_Echo ) )
-    IF ( Angles%Nbeta > Number_to_Echo ) WRITE( PRTFile, "( G14.6 )" ) &
-                                            ' ... ', Angles%beta( Angles%Nbeta )
+    IF ( Angles%Nbeta >= 1 ) THEN
+        WRITE(msgBuf,'(5G14.6)') Angles%beta( 1:MIN(Angles%Nbeta,Number_to_Echo) )
+        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    END IF
+    IF ( Angles%Nbeta > Number_to_Echo ) THEN
+        WRITE(msgBuf,'(G14.6)') ' ... ', Angles%beta( Angles%Nbeta )
+        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    END IF
 #endif /* IHOP_WRITE_OUT */
 
     IF ( Angles%Nbeta>1 .AND. &

--- a/ihop/angle_mod.F90
+++ b/ihop/angle_mod.F90
@@ -83,8 +83,9 @@ CONTAINS
     ALLOCATE( Angles%alpha( MAX( 3, Angles%Nalpha ) ), STAT = iAllocStat )
     IF ( iAllocStat /= 0 ) THEN
 #ifdef IHOP_WRITE_OUT
-        WRITE(errorMessageUnit,'(2A)') 'ANGLEMOD ReadRayElevationAngles:', &
+        WRITE(msgBuf,'(2A)') 'ANGLEMOD ReadRayElevationAngles:', &
         'Insufficient memory to store beam angles'
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
         STOP 'ABNORMAL END: S/R ReadRayElevationAngles'
     END IF
@@ -128,8 +129,9 @@ CONTAINS
     IF ( Angles%Nalpha>1 .AND. &
     Angles%alpha(Angles%Nalpha) == Angles%alpha(1) ) THEN
 #ifdef IHOP_WRITE_OUT
-        WRITE(errorMessageUnit,'(2A)') 'ANGLEMOD ReadRayElevationAngles:', &
+        WRITE(msgBuf,'(2A)') 'ANGLEMOD ReadRayElevationAngles:', &
         'First and last beam take-off angle are identical'
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
         STOP 'ABNORMAL END: S/R ReadRayElevationAngles'
     END IF
@@ -138,8 +140,9 @@ CONTAINS
         IF ( Angles%iSingle_alpha<1 .OR. &
            Angles%iSingle_alpha>Angles%Nalpha ) THEN
 #ifdef IHOP_WRITE_OUT
-            WRITE(errorMessageUnit,'(2A)') 'ANGLEMOD ReadRayElevationAngles:', &
+            WRITE(msgBuf,'(2A)') 'ANGLEMOD ReadRayElevationAngles:', &
             'Selected beam, iSingl not in [ 1, Angles%Nalpha ]'
+            CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
             STOP 'ABNORMAL END: S/R ReadRayElevationAngles'
         END IF
@@ -163,8 +166,9 @@ CONTAINS
     CHARACTER (LEN= 6), INTENT( IN ) :: TopOpt, RunType
 
 #ifdef IHOP_WRITE_OUT
-    WRITE(errorMessageUnit,'(2A)') 'ANGLEMOD ReadBearingElevationAngles:', &
+    WRITE(msgBuf,'(2A)') 'ANGLEMOD ReadBearingElevationAngles:', &
                  '3D rays not supported in ihop'
+    CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
     STOP 'ABNORMAL END: S/R ReadBearingElevationAngles'
 
@@ -187,8 +191,9 @@ CONTAINS
     ALLOCATE( Angles%beta( MAX( 3, Angles%Nbeta ) ), STAT = iAllocStat )
     IF ( iAllocStat /= 0 ) THEN
 #ifdef IHOP_WRITE_OUT
-        WRITE(errorMessageUnit,'(2A)') 'ANGLEMOD ReadBearingElevationAngles:', &
+        WRITE(msgBuf,'(2A)') 'ANGLEMOD ReadBearingElevationAngles:', &
                         'Insufficient memory to store beam angles'
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
         STOP 'ABNORMAL END: S/R ReadBearingElevationAngles'
     END IF
@@ -219,8 +224,9 @@ CONTAINS
        ALLOCATE( Angles%beta( MAX( 3, Angles%Nbeta ) ), STAT = iAllocStat )
         IF ( iAllocStat /= 0 ) THEN
 #ifdef IHOP_WRITE_OUT
-            WRITE(errorMessageUnit,'(2A)') 'ANGLEMOD ReadBearingElevationAngles:', &
+            WRITE(msgBuf,'(2A)') 'ANGLEMOD ReadBearingElevationAngles:', &
                             'Insufficient memory to store beam angles'
+            CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
             STOP 'ABNORMAL END: S/R ReadBearingElevationAngles'
         END IF
@@ -254,8 +260,10 @@ CONTAINS
     IF ( Angles%Nbeta>1 .AND. &
         Angles%beta( Angles%Nbeta )==Angles%beta(1) ) THEN
 #ifdef IHOP_WRITE_OUT
-        WRITE(errorMessageUnit,'(2A)') 'ANGLEMOD ReadBearingElevationAngles:', &
+        WRITE(msgBuf,'(2A)') 'ANGLEMOD ReadBearingElevationAngles:', &
          'First and last beam take-off angle are identical'
+        CALL PRINT_ERROR( msgBuf,myThid )
+
 #endif /* IHOP_WRITE_OUT */
         STOP 'ABNORMAL END: S/R ReadBearingElevationAngles'
     END IF
@@ -264,8 +272,9 @@ CONTAINS
         IF ( Angles%iSingle_beta < 1 .OR. &
             Angles%iSingle_beta > Angles%Nbeta ) THEN
 #ifdef IHOP_WRITE_OUT
-            WRITE(errorMessageUnit,'(2A)') 'ANGLEMOD ReadBearingElevationAngles:', &
+            WRITE(msgBuf,'(2A)') 'ANGLEMOD ReadBearingElevationAngles:', &
             'Selected beam, iSingl not in [ 1, Angles%Nbeta ]'
+            CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
             STOP 'ABNORMAL END: S/R ReadBearingElevationAngles'
         END IF

--- a/ihop/angle_mod.F90
+++ b/ihop/angle_mod.F90
@@ -107,10 +107,10 @@ CONTAINS
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     WRITE(msgBuf,'(A)')
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-    WRITE(msgBuf,'(A,I)') 'Number of beams in elevation   = ', Angles%Nalpha
+    WRITE(msgBuf,'(A,I10)') 'Number of beams in elevation   = ', Angles%Nalpha
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     IF ( Angles%iSingle_alpha > 0 ) THEN
-        WRITE(msgBuf,'(A,I)') 'Trace only beam number ', Angles%iSingle_alpha
+        WRITE(msgBuf,'(A,I10)') 'Trace only beam number ', Angles%iSingle_alpha
         CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     END IF
     WRITE(msgBuf,'(A)') 'Beam take-off angles (degrees)'
@@ -238,10 +238,10 @@ CONTAINS
 #ifdef IHOP_WRITE_OUT
     WRITE(msgBuf,'(A)')
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-    WRITE(msgBuf,'(A,I)') 'Number of beams in bearing   = ', Angles%Nbeta
+    WRITE(msgBuf,'(A,I10)') 'Number of beams in bearing   = ', Angles%Nbeta
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     IF ( Angles%iSingle_beta > 0 ) THEN
-        WRITE(msgBuf,'(A,I)') 'Trace only beam number ', Angles%iSingle_beta
+        WRITE(msgBuf,'(A,I10)') 'Trace only beam number ', Angles%iSingle_beta
         CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     END IF
     WRITE(msgBuf,'(A)') 'Beam take-off angles (degrees)'

--- a/ihop/bdry_mod.F90
+++ b/ihop/bdry_mod.F90
@@ -68,8 +68,13 @@ CONTAINS
   SUBROUTINE ReadATI( FileRoot, TopATI, DepthT, myThid ) 
     ! Reads in the top altimetry
 
-    INTEGER, INTENT( IN ) :: myThid
-
+  !     == Routine Arguments ==
+  !     myThid :: Thread number. Unused by IESCO
+  !     msgBuf :: Used to build messages for printing.
+    INTEGER, INTENT( IN )   :: myThid
+    CHARACTER*(MAX_LEN_MBUF):: msgBuf
+  
+  !     == Local Variables ==
     CHARACTER (LEN= 1), INTENT( IN ) :: TopATI
     REAL (KIND=_RL90),  INTENT( IN ) :: DepthT
     REAL (KIND=_RL90),  ALLOCATABLE  :: phi( : )
@@ -78,17 +83,21 @@ CONTAINS
     SELECT CASE ( TopATI )
     CASE ( '~', '*' )
 #ifdef IHOP_WRITE_OUT
-       WRITE( PRTFile, * ) '______________________________________________', &
+       WRITE(msgBuf,'(2A)') '______________________________________________', &
                            '____________________________'
-       WRITE( PRTFile, * )
-       WRITE( PRTFile, * ) 'Using top-altimetry file'
+       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+       WRITE(msgBuf,'(A)') NEW_LINE('a')
+       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+       WRITE(msgBuf,'(A)') 'Using top-altimetry file'
+       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
 
        OPEN( UNIT = ATIFile,   FILE = TRIM( FileRoot ) // '.ati', &
              STATUS = 'OLD', IOSTAT = IOStat, ACTION = 'READ' )
         IF ( IOsTAT /= 0 ) THEN
 #ifdef IHOP_WRITE_OUT
-            WRITE( PRTFile, * ) 'ATIFile = ', TRIM( FileRoot ) // '.ati'
+            WRITE(msgBuf,'(A)') 'ATIFile = ', TRIM( FileRoot ) // '.ati'
+            CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
             WRITE(errorMessageUnit,'(2A)') 'BDRYMOD ReadATI', &
                 'Unable to open altimetry file'
 #endif /* IHOP_WRITE_OUT */
@@ -99,11 +108,13 @@ CONTAINS
        AltiType: SELECT CASE ( atiType( 1 : 1 ) )
        CASE ( 'C' )
 #ifdef IHOP_WRITE_OUT
-          WRITE( PRTFile, * ) 'Curvilinear Interpolation'
+          WRITE(msgBuf,'(A)') 'Curvilinear Interpolation'
+          CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
        CASE ( 'L' )
 #ifdef IHOP_WRITE_OUT
-          WRITE( PRTFile, * ) 'Piecewise linear interpolation'
+          WRITE(msgBuf,'(A)') 'Piecewise linear interpolation'
+          CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
        CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
@@ -115,7 +126,8 @@ CONTAINS
 
        READ(  ATIFile, * ) NatiPts
 #ifdef IHOP_WRITE_OUT
-       WRITE( PRTFile, * ) 'Number of altimetry points = ', NatiPts
+       WRITE(msgBuf,'(A,I)') 'Number of altimetry points = ', NatiPts
+       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
        ! we'll be extending the altimetry to infinity to the left and right
        NatiPts = NatiPts + 2  
@@ -130,8 +142,10 @@ CONTAINS
         END IF
 
 #ifdef IHOP_WRITE_OUT
-       WRITE( PRTFile, * )
-       WRITE( PRTFile, * ) ' Range (km)  Depth (m)'
+       WRITE(msgBuf,'(A)') NEW_LINE('a')
+       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+       WRITE(msgBuf,'(A)') ' Range (km)  Depth (m)'
+       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
 
        atiPt: DO ii = 2, NatiPts - 1
@@ -141,7 +155,8 @@ CONTAINS
             READ(  ATIFile, * ) Top( ii )%x
 #ifdef IHOP_WRITE_OUT
             IF ( ii < Number_to_Echo .OR. ii == NatiPts ) THEN   
-                WRITE( PRTFile, FMT = "(2G11.3)" ) Top( ii )%x 
+                WRITE( msgBuf,"(2G11.3)" ) Top( ii )%x 
+                CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
             END IF
 #endif /* IHOP_WRITE_OUT */
           CASE ( 'L' )
@@ -150,9 +165,10 @@ CONTAINS
                                  Top( ii )%HS%alphaI, Top( ii )%HS%betaI
 #ifdef IHOP_WRITE_OUT
              IF ( ii < Number_to_Echo .OR. ii == NatiPts ) THEN   
-                WRITE( PRTFile, FMT = "(7G11.3)" ) &
+                WRITE( msgBuf,"(7G11.3)" ) &
                     Top( ii )%x, Top( ii )%HS%alphaR, Top( ii )%HS%betaR, &
                     Top( ii )%HS%rho, Top( ii )%HS%alphaI, Top( ii )%HS%betaI
+                CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
              END IF
 #endif /* IHOP_WRITE_OUT */
           CASE DEFAULT
@@ -208,8 +224,13 @@ CONTAINS
 
     ! Reads in the bottom bathymetry
 
-    INTEGER, INTENT( IN ) :: myThid
-
+  !     == Routine Arguments ==
+  !     myThid :: Thread number. Unused by IESCO
+  !     msgBuf :: Used to build messages for printing.
+    INTEGER, INTENT( IN )   :: myThid
+    CHARACTER*(MAX_LEN_MBUF):: msgBuf
+  
+  !     == Local Variables ==
     CHARACTER (LEN= 1), INTENT( IN ) :: BotBTY
     REAL (KIND=_RL90),  INTENT( IN ) :: DepthB
     CHARACTER (LEN=80), INTENT( IN ) :: FileRoot
@@ -217,17 +238,21 @@ CONTAINS
     SELECT CASE ( BotBTY )
     CASE ( '~', '*' )
 #ifdef IHOP_WRITE_OUT
-       WRITE( PRTFile, * ) '________________________________________________', &
+       WRITE(msgBuf,'(2A)')'________________________________________________', &
                            '__________________________'
-       WRITE( PRTFile, * )
-       WRITE( PRTFile, * ) 'Using bottom-bathymetry file'
+       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+       WRITE(msgBuf,'(A)') NEW_LINE('a')
+       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+       WRITE(msgBuf,'(A)') 'Using bottom-bathymetry file'
+       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
 
        OPEN( UNIT = BTYFile, FILE = TRIM( FileRoot ) // '.bty', STATUS = 'OLD',& 
              IOSTAT = IOStat, ACTION = 'READ' )
         IF ( IOsTAT /= 0 ) THEN
 #ifdef IHOP_WRITE_OUT
-            WRITE( PRTFile, * ) 'BTYFile = ', TRIM( FileRoot ) // '.bty'
+            WRITE(msgBuf,'(A)') 'BTYFile = ', TRIM( FileRoot ) // '.bty'
+            CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
             WRITE(errorMessageUnit,'(2A)') 'BDRYMOD ReadBTY: ', &
                                  'Unable to open bathymetry file'
 #endif /* IHOP_WRITE_OUT */
@@ -239,11 +264,13 @@ CONTAINS
        BathyType: SELECT CASE ( btyType( 1 : 1 ) )
        CASE ( 'C' )
 #ifdef IHOP_WRITE_OUT
-          WRITE( PRTFile, * ) 'Curvilinear Interpolation'
+          WRITE(msgBuf,'(A)') 'Curvilinear Interpolation'
+          CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
        CASE ( 'L' )
 #ifdef IHOP_WRITE_OUT
-          WRITE( PRTFile, * ) 'Piecewise linear interpolation'
+          WRITE(msgBuf,'(A)') 'Piecewise linear interpolation'
+          CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
        CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
@@ -256,7 +283,8 @@ CONTAINS
 
        READ(  BTYFile, * ) NbtyPts
 #ifdef IHOP_WRITE_OUT
-       WRITE( PRTFile, * ) 'Number of bathymetry points = ', NbtyPts
+       WRITE(msgBuf,'(A,I)') 'Number of bathymetry points = ', NbtyPts
+       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
 
         ! we'll be extending the bathymetry to infinity on both sides
@@ -271,18 +299,26 @@ CONTAINS
         END IF
         
 #ifdef IHOP_WRITE_OUT
-       WRITE( PRTFile, * )
+       WRITE(msgBuf,'(A)') NEW_LINE('a')
+       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
        BathyTypeB: SELECT CASE ( btyType( 2 : 2 ) )
        CASE ( 'S', '' )
 #ifdef IHOP_WRITE_OUT
-          WRITE( PRTFile, * ) 'Short format (bathymetry only)'
-          WRITE( PRTFile, * ) ' Range (km)  Depth (m)'
+          WRITE(msgBuf,'(A)') 'Short format (bathymetry only)'
+          CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+          WRITE(msgBuf,'(A)') ' Range (km)  Depth (m)'
+          CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
        CASE ( 'L' )
 #ifdef IHOP_WRITE_OUT
-          WRITE( PRTFile, * ) 'Long format (bathymetry and geoacoustics)'
-          WRITE( PRTFile, "( ' Range (km)  Depth (m)  alphaR (m/s)  betaR  rho (g/cm^3)  alphaI     betaI', / )" )
+          WRITE(msgBuf,'(A)') 'Long format (bathymetry and geoacoustics)'
+          CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+          WRITE(msgBuf,'(A)') &
+              ' Range (km)  Depth (m)  alphaR (m/s)  betaR  rho (g/cm^3)  alphaI     betaI'
+          CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+          WRITE(msgBuf,'(A)') NEW_LINE('a')
+          CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
        CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
@@ -299,7 +335,8 @@ CONTAINS
              READ(  BTYFile, * ) Bot( ii )%x
 #ifdef IHOP_WRITE_OUT
              IF ( ii < Number_to_Echo .OR. ii == NbtyPts ) THEN  
-                WRITE( PRTFile, FMT = "(2G11.3)" ) Bot( ii )%x
+                WRITE(msgBuf,'(2G11.3)' ) Bot( ii )%x
+                CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
              END IF
 #endif /* IHOP_WRITE_OUT */
           CASE ( 'L' )       ! long format
@@ -308,9 +345,10 @@ CONTAINS
                                  Bot( ii )%HS%alphaI, Bot( ii )%HS%betaI
 #ifdef IHOP_WRITE_OUT
              IF ( ii < Number_to_Echo .OR. ii == NbtyPts ) THEN   
-                WRITE( PRTFile, FMT="( F10.2, F10.2, 3X, 2F10.2, 3X, F6.2, 3X, 2F10.4 )" ) &
+                WRITE( msgBuf,'(2F10.2,3X,2F10.2,3X,F6.2,3X,2F10.4)' ) &
                    Bot( ii )%x, Bot( ii )%HS%alphaR, Bot( ii )%HS%betaR, &
                    Bot( ii )%HS%rho, Bot( ii )%HS%alphaI, Bot( ii )%HS%betaI
+                CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
              END IF
 #endif /* IHOP_WRITE_OUT */
           CASE DEFAULT
@@ -337,7 +375,8 @@ CONTAINS
 
     CASE DEFAULT   ! no bathymetry given, use SSP depth for flat bottom
 #ifdef IHOP_WRITE_OUT
-        WRITE( PRTFile, * ) 'No BTYFile; assuming flat bottom'
+        WRITE(msgBuf,'(A)') 'No BTYFile; assuming flat bottom'
+        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
         ALLOCATE( Bot( 2 ), Stat = IAllocStat )
         IF ( IAllocStat /= 0 ) THEN
@@ -478,8 +517,13 @@ CONTAINS
 
     ! Get the Top segment info (index and range interval) for range, r
 
-    INTEGER, INTENT( IN ) :: myThid
-
+  !     == Routine Arguments ==
+  !     myThid :: Thread number. Unused by IESCO
+  !     msgBuf :: Used to build messages for printing.
+    INTEGER, INTENT( IN )   :: myThid
+    CHARACTER*(MAX_LEN_MBUF):: msgBuf
+  
+  !     == Local Variables ==
     INTEGER IsegTopT( 1 )
     REAL (KIND=_RL90), INTENT( IN ) :: r
 
@@ -492,9 +536,12 @@ CONTAINS
        rTopSeg = [ Top( IsegTop )%x( 1 ), Top( IsegTop+1 )%x( 1 ) ]   
     ELSE
 #ifdef IHOP_WRITE_OUT
-        WRITE( PRTFile, * ) 'r = ', r
-        WRITE( PRTFile, * ) 'rLeft  = ', Top( 1       )%x( 1 )
-        WRITE( PRTFile, * ) 'rRight = ', Top( NatiPts )%x( 1 )
+        WRITE(msgBuf,'(A,F10.4)') 'r = ', r
+        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(A,F10.4)') 'rLeft  = ', Top( 1       )%x( 1 )
+        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(A,F10.4)') 'rRight = ', Top( NatiPts )%x( 1 )
+        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
         WRITE(errorMessageUnit,'(2A)') 'BDRYMOD GetTopSeg', &
                              'Top altimetry undefined above the ray'
 #endif /* IHOP_WRITE_OUT */
@@ -509,8 +556,13 @@ CONTAINS
   SUBROUTINE GetBotSeg( r, myThid )
 
     ! Get the Bottom segment info (index and range interval) for range, r
-    INTEGER, INTENT( IN ) :: myThid
-
+  !     == Routine Arguments ==
+  !     myThid :: Thread number. Unused by IESCO
+  !     msgBuf :: Used to build messages for printing.
+    INTEGER, INTENT( IN )   :: myThid
+    CHARACTER*(MAX_LEN_MBUF):: msgBuf
+  
+  !     == Local Variables ==
     INTEGER IsegBotT( 1 )
     REAL (KIND=_RL90), INTENT( IN ) :: r
 
@@ -522,9 +574,12 @@ CONTAINS
        rBotSeg = [ Bot( IsegBot )%x( 1 ), Bot( IsegBot + 1 )%x( 1 ) ]
     ELSE
 #ifdef IHOP_WRITE_OUT
-        WRITE( PRTFile, * ) 'r = ', r
-        WRITE( PRTFile, * ) 'rLeft  = ', Bot( 1       )%x( 1 )
-        WRITE( PRTFile, * ) 'rRight = ', Bot( NbtyPts )%x( 1 )
+        WRITE(msgBuf,'(A,F10.4)') 'r = ', r
+        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(A,F10.4)') 'rLeft  = ', Bot( 1       )%x( 1 )
+        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(A,F10.4)') 'rRight = ', Bot( NbtyPts )%x( 1 )
+        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
         WRITE(errorMessageUnit,'(2A)') 'BDRYMOD GetBotSeg', &
                              'Bottom bathymetry undefined below the source'
 #endif /* IHOP_WRITE_OUT */

--- a/ihop/bdry_mod.F90
+++ b/ihop/bdry_mod.F90
@@ -128,7 +128,7 @@ CONTAINS
 
        READ(  ATIFile, * ) NatiPts
 #ifdef IHOP_WRITE_OUT
-       WRITE(msgBuf,'(A,I)') 'Number of altimetry points = ', NatiPts
+       WRITE(msgBuf,'(A,I10)') 'Number of altimetry points = ', NatiPts
        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
        ! we'll be extending the altimetry to infinity to the left and right
@@ -292,7 +292,7 @@ CONTAINS
 
        READ(  BTYFile, * ) NbtyPts
 #ifdef IHOP_WRITE_OUT
-       WRITE(msgBuf,'(A,I)') 'Number of bathymetry points = ', NbtyPts
+       WRITE(msgBuf,'(A,I10)') 'Number of bathymetry points = ', NbtyPts
        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
 

--- a/ihop/bdry_mod.F90
+++ b/ihop/bdry_mod.F90
@@ -98,8 +98,9 @@ CONTAINS
 #ifdef IHOP_WRITE_OUT
             WRITE(msgBuf,'(A)') 'ATIFile = ', TRIM( FileRoot ) // '.ati'
             CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-            WRITE(errorMessageUnit,'(2A)') 'BDRYMOD ReadATI', &
+            WRITE(msgBuf,'(2A)') 'BDRYMOD ReadATI', &
                 'Unable to open altimetry file'
+            CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
             STOP 'ABNORMAL END: S/R ReadATI'
         END IF
@@ -118,8 +119,9 @@ CONTAINS
 #endif /* IHOP_WRITE_OUT */
        CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
-            WRITE(errorMessageUnit,'(2A)') 'BDRYMOD ReadATI', &
+            WRITE(msgBuf,'(2A)') 'BDRYMOD ReadATI', &
                        'Unknown option for selecting altimetry interpolation'
+            CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
             STOP 'ABNORMAL END: S/R ReadATI'
        END SELECT AltiType
@@ -135,8 +137,9 @@ CONTAINS
        ALLOCATE( Top(  NatiPts ), phi( NatiPts ), Stat = IAllocStat )
        IF ( IAllocStat /= 0 ) THEN
 #ifdef IHOP_WRITE_OUT
-            WRITE(errorMessageUnit,'(2A)') 'BDRYMOD ReadATI', &
+            WRITE(msgBuf,'(2A)') 'BDRYMOD ReadATI', &
                 'Insufficient memory for altimetry data: reduce # ati points'
+            CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
             STOP 'ABNORMAL END: S/R ReadATI'
         END IF
@@ -173,16 +176,18 @@ CONTAINS
 #endif /* IHOP_WRITE_OUT */
           CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
-            WRITE(errorMessageUnit,'(2A)') 'BDRYMOD ReadATI', &
+            WRITE(msgBuf,'(2A)') 'BDRYMOD ReadATI', &
                             'Unknown option for selecting altimetry option'
+            CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
             STOP 'ABNORMAL END: S/R ReadATI'
           END SELECT
 
           IF ( Top( ii )%x( 2 ) < DepthT ) THEN
 #ifdef IHOP_WRITE_OUT
-            WRITE(errorMessageUnit,'(2A)') 'BDRYMOD ReadATI', &
+            WRITE(msgBuf,'(2A)') 'BDRYMOD ReadATI', &
                 'Altimetry rises above highest point in the sound speed profile'
+            CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
             STOP 'ABNORMAL END: S/R ReadATI'
           END IF
@@ -196,8 +201,9 @@ CONTAINS
         ALLOCATE( Top( 2 ), Stat = IAllocStat )
         IF ( IAllocStat /= 0 ) THEN
 #ifdef IHOP_WRITE_OUT
-            WRITE(errorMessageUnit,'(2A)') 'BDRYMOD ReadATI', &
+            WRITE(msgBuf,'(2A)') 'BDRYMOD ReadATI', &
                                     'Insufficient memory for altimetry data'
+            CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
             STOP 'ABNORMAL END: S/R ReadATI'
         END IF
@@ -209,8 +215,9 @@ CONTAINS
 
     IF ( .NOT. monotonic( Top%x( 1 ), NAtiPts ) ) THEN
 #ifdef IHOP_WRITE_OUT
-        WRITE(errorMessageUnit,'(2A)') 'BDRYMOD ReadATI', &
+        WRITE(msgBuf,'(2A)') 'BDRYMOD ReadATI', &
                         'Altimetry ranges are not monotonically increasing'
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
         STOP 'ABNORMAL END: S/R ReadATI'
     END IF 
@@ -253,8 +260,9 @@ CONTAINS
 #ifdef IHOP_WRITE_OUT
             WRITE(msgBuf,'(A)') 'BTYFile = ', TRIM( FileRoot ) // '.bty'
             CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-            WRITE(errorMessageUnit,'(2A)') 'BDRYMOD ReadBTY: ', &
+            WRITE(msgBuf,'(2A)') 'BDRYMOD ReadBTY: ', &
                                  'Unable to open bathymetry file'
+            CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
             STOP 'ABNORMAL END: S/R ReadBTY'
        END IF
@@ -274,8 +282,9 @@ CONTAINS
 #endif /* IHOP_WRITE_OUT */
        CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
-            WRITE(errorMessageUnit,'(2A)') 'BDRYMOD ReadBTY: ', &
+            WRITE(msgBuf,'(2A)') 'BDRYMOD ReadBTY: ', &
                     'Unknown option for selecting bathymetry interpolation'
+            CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
             STOP 'ABNORMAL END: S/R ReadBTY'
        END SELECT BathyType
@@ -292,8 +301,9 @@ CONTAINS
         ALLOCATE( Bot( NbtyPts ), Stat = IAllocStat )
         IF ( IAllocStat /= 0 ) THEN
 #ifdef IHOP_WRITE_OUT
-            WRITE(errorMessageUnit,'(2A)') 'BDRYMOD ReadBTY: ', &
+            WRITE(msgBuf,'(2A)') 'BDRYMOD ReadBTY: ', &
                 'Insufficient memory for bathymetry data: reduce # bty points'
+            CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
             STOP 'ABNORMAL END: S/R ReadBTY'
         END IF
@@ -322,8 +332,9 @@ CONTAINS
 #endif /* IHOP_WRITE_OUT */
        CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
-            WRITE(errorMessageUnit,'(2A)') 'BDRYMOD ReadBTY: ', &
+            WRITE(msgBuf,'(2A)') 'BDRYMOD ReadBTY: ', &
                     'Unknown option for selecting bathymetry interpolation'
+            CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
             STOP 'ABNORMAL END: S/R ReadBTY'
        END SELECT BathyTypeB
@@ -353,16 +364,18 @@ CONTAINS
 #endif /* IHOP_WRITE_OUT */
           CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
-            WRITE(errorMessageUnit,'(2A)') 'BDRYMOD ReadBTY: ', &
+            WRITE(msgBuf,'(2A)') 'BDRYMOD ReadBTY: ', &
                     'Unknown option for selecting bathymetry interpolation'
+            CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
             STOP 'ABNORMAL END: S/R ReadBTY'
           END SELECT
 
           IF ( Bot( ii )%x( 2 ) > DepthB ) THEN
 #ifdef IHOP_WRITE_OUT
-            WRITE(errorMessageUnit,'(2A)') 'BDRYMOD ReadBTY: ', &
+            WRITE(msgBuf,'(2A)') 'BDRYMOD ReadBTY: ', &
                 'Bathymetry drops below lowest point in the sound speed profile'
+            CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
             STOP 'ABNORMAL END: S/R ReadBTY'
           END IF
@@ -381,8 +394,9 @@ CONTAINS
         ALLOCATE( Bot( 2 ), Stat = IAllocStat )
         IF ( IAllocStat /= 0 ) THEN
 #ifdef IHOP_WRITE_OUT
-            WRITE(errorMessageUnit,'(2A)') 'BDRYMOD ReadBTY: ', &
+            WRITE(msgBuf,'(2A)') 'BDRYMOD ReadBTY: ', &
                                  'Insufficient memory for bathymetry data'
+            CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
             STOP 'ABNORMAL END: S/R ReadBTY'
         END IF
@@ -394,8 +408,9 @@ CONTAINS
 
     IF ( .NOT. monotonic( Bot%x( 1 ), NBtyPts ) ) THEN
 #ifdef IHOP_WRITE_OUT
-        WRITE(errorMessageUnit,'(2A)') 'BDRYMOD ReadBTY: ', &
+        WRITE(msgBuf,'(2A)') 'BDRYMOD ReadBTY: ', &
                     'Bathymetry ranges are not monotonically increasing'
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
         STOP 'ABNORMAL END: S/R ReadBTY'
     END IF 
@@ -542,8 +557,9 @@ CONTAINS
         CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
         WRITE(msgBuf,'(A,F10.4)') 'rRight = ', Top( NatiPts )%x( 1 )
         CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-        WRITE(errorMessageUnit,'(2A)') 'BDRYMOD GetTopSeg', &
+        WRITE(msgBuf,'(2A)') 'BDRYMOD GetTopSeg', &
                              'Top altimetry undefined above the ray'
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
         STOP 'ABNORMAL END: S/R GetTopSeg'
     ENDIF
@@ -580,8 +596,9 @@ CONTAINS
         CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
         WRITE(msgBuf,'(A,F10.4)') 'rRight = ', Bot( NbtyPts )%x( 1 )
         CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-        WRITE(errorMessageUnit,'(2A)') 'BDRYMOD GetBotSeg', &
+        WRITE(msgBuf,'(2A)') 'BDRYMOD GetBotSeg', &
                              'Bottom bathymetry undefined below the source'
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
         STOP 'ABNORMAL END: S/R GetBotSeg'
     ENDIF

--- a/ihop/bdry_mod.F90
+++ b/ihop/bdry_mod.F90
@@ -84,9 +84,9 @@ CONTAINS
     CASE ( '~', '*' )
 #ifdef IHOP_WRITE_OUT
        WRITE(msgBuf,'(2A)') '______________________________________________', &
-                           '____________________________'
+                           '_____________'
        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-       WRITE(msgBuf,'(A)') NEW_LINE('a')
+       WRITE(msgBuf,'(A)') 
        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
        WRITE(msgBuf,'(A)') 'Using top-altimetry file'
        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
@@ -142,7 +142,7 @@ CONTAINS
         END IF
 
 #ifdef IHOP_WRITE_OUT
-       WRITE(msgBuf,'(A)') NEW_LINE('a')
+       WRITE(msgBuf,'(A)') 
        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
        WRITE(msgBuf,'(A)') ' Range (km)  Depth (m)'
        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
@@ -239,9 +239,9 @@ CONTAINS
     CASE ( '~', '*' )
 #ifdef IHOP_WRITE_OUT
        WRITE(msgBuf,'(2A)')'________________________________________________', &
-                           '__________________________'
+                           '___________'
        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-       WRITE(msgBuf,'(A)') NEW_LINE('a')
+       WRITE(msgBuf,'(A)') 
        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
        WRITE(msgBuf,'(A)') 'Using bottom-bathymetry file'
        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
@@ -299,7 +299,7 @@ CONTAINS
         END IF
         
 #ifdef IHOP_WRITE_OUT
-       WRITE(msgBuf,'(A)') NEW_LINE('a')
+       WRITE(msgBuf,'(A)') 
        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
        BathyTypeB: SELECT CASE ( btyType( 2 : 2 ) )
@@ -317,7 +317,7 @@ CONTAINS
           WRITE(msgBuf,'(A)') &
               ' Range (km)  Depth (m)  alphaR (m/s)  betaR  rho (g/cm^3)  alphaI     betaI'
           CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-          WRITE(msgBuf,'(A)') NEW_LINE('a')
+          WRITE(msgBuf,'(A)') 
           CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
        CASE DEFAULT

--- a/ihop/beampattern.F90
+++ b/ihop/beampattern.F90
@@ -28,8 +28,13 @@ MODULE beamPattern
 CONTAINS
   SUBROUTINE ReadPat( FileRoot, myThid )
 
-    INTEGER, INTENT( IN ) :: myThid 
-
+  !     == Routine Arguments ==
+  !     myThid :: Thread number. Unused by IESCO
+  !     msgBuf :: Used to build messages for printing.
+    INTEGER, INTENT( IN )   :: myThid
+    CHARACTER*(MAX_LEN_MBUF):: msgBuf
+  
+  !     == Local Variables ==
     INTEGER                          :: I, IAllocStat, IOStat
     CHARACTER (LEN=80), INTENT( IN ) :: FileRoot
 
@@ -45,8 +50,9 @@ CONTAINS
        IF ( IOstat /= 0 ) THEN
 #ifdef IHOP_WRITE_OUT
             WRITE( PRTFile, * ) 'SBPFile = ', TRIM( FileRoot ) // '.sbp'
-            WRITE(errorMessageUnit,'(2A)') 'BEAMPATTERN ReadPat: ', &
+            WRITE(msgBuf,'(2A)') 'BEAMPATTERN ReadPat: ', &
                                  'Unable to open source beampattern file'
+            CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
             STOP 'ABNORMAL END: S/R ReadPat'
        END IF
@@ -59,8 +65,9 @@ CONTAINS
        ALLOCATE( SrcBmPat( NSBPPts, 2 ), Stat = IAllocStat )
        IF ( IAllocStat /= 0 ) THEN
 #ifdef IHOP_WRITE_OUT
-            WRITE(errorMessageUnit,'(2A)') 'BEAMPATTERN ReadPat: ', &
+            WRITE(msgBuf,'(2A)') 'BEAMPATTERN ReadPat: ', &
             'Insufficient memory for beam pattern data: reduce # SBP points'
+            CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
             STOP 'ABNORMAL END: S/R ReadPat'
         END IF
@@ -82,8 +89,9 @@ CONTAINS
         ALLOCATE( SrcBmPat( 2, 2 ), Stat = IAllocStat )
         IF ( IAllocStat /= 0 ) THEN
 #ifdef IHOP_WRITE_OUT
-            WRITE(errorMessageUnit,'(2A)') 'BEAMPATTERN ReadPat: ', &
+            WRITE(msgBuf,'(2A)') 'BEAMPATTERN ReadPat: ', &
                                  'Insufficient memory'
+            CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
             STOP 'ABNORMAL END: S/R ReadPat'
         END IF

--- a/ihop/bellhop.F90
+++ b/ihop/bellhop.F90
@@ -262,6 +262,8 @@ CONTAINS
   
 #ifdef IHOP_WRITE_OUT
     ! print run time
+    WRITE(msgBuf, '(A)' )
+    CALL PRINT_MESSAGE(msgBuf, PRTFile, SQUEEZE_RIGHT, myThid)
     WRITE(msgBuf, '(A,G15.3,A)' ) 'CPU Time = ', Tstop-Tstart, 's'
     CALL PRINT_MESSAGE(msgBuf, PRTFile, SQUEEZE_RIGHT, myThid)
   
@@ -373,7 +375,7 @@ CONTAINS
           ! allow space for at least MinNArr arrivals
           MaxNArr = MAX( ArrivalsStorage / ( NRz_per_range * Pos%NRr ), MinNArr )
 #ifdef IHOP_WRITE_OUT
-          WRITE( msgBuf,'(A)' ) NEW_LINE('a')
+          WRITE( msgBuf,'(A)' ) 
           CALL PRINT_MESSAGE(msgBuf, PRTFile, SQUEEZE_RIGHT, myThid)
           WRITE( msgBuf,'(A,I,A)' ) 'Max. # of arrivals = ', MaxNArr
           CALL PRINT_MESSAGE(msgBuf, PRTFile, SQUEEZE_RIGHT, myThid)
@@ -398,7 +400,7 @@ CONTAINS
       NArr( 1:NRz_per_range, 1:Pos%NRr ) = 0 ! IEsco22 unnecessary? NArr = 0 below
   
 #ifdef IHOP_WRITE_OUT
-      WRITE(msgBuf,'(A)') NEW_LINE('a')
+      WRITE(msgBuf,'(A)') 
       CALL PRINT_MESSAGE(msgBuf, PRTFile, SQUEEZE_RIGHT, myThid)
 #endif /* IHOP_WRITE_OUT */
   

--- a/ihop/bellhop.F90
+++ b/ihop/bellhop.F90
@@ -92,6 +92,7 @@ CONTAINS
         WRITE(myProcessStr, '(I4.4)') myProcId
         WRITE(fNam,'(A,A,A,A)') TRIM(IHOP_fileroot),'.',myProcessStr(1:4),'.prt'
         OPEN(PRTFile, FILE = fNam, STATUS = 'UNKNOWN', IOSTAT = iostat )
+#ifdef ALLOW_USE_MPI
     ELSE ! using MPI
         CALL MPI_COMM_RANK( MPI_COMM_MODEL, mpiMyId, mpiRC )
         myProcId = mpiMyId
@@ -103,9 +104,9 @@ CONTAINS
         pidIO    = mpiPidIo
 
         IF( mpiPidIo.EQ.myProcId ) THEN
-# ifdef SINGLE_DISK_IO
+#  ifdef SINGLE_DISK_IO
          IF( myProcId.eq.0) THEN
-# endif
+#  endif
             WRITE(fNam,'(A,A,A,A)') &
                 TRIM(IHOP_fileroot),'.',myProcessStr(1:iTmp),'.prt'
             OPEN(PRTFile, FILE=fNam, STATUS='UNKNOWN', IOSTAT=iostat )
@@ -116,10 +117,11 @@ CONTAINS
                 CALL PRINT_ERROR( msgBuf, myThid )
                 STOP 'ABNORMAL END: S/R IHOP_INIT'
             END IF
-# ifdef SINGLE_DISK_IO
+#  ifdef SINGLE_DISK_IO
          END IF
-# endif
+#  endif
         END IF
+# endif /* ALLOW_USE_MPI */
     END IF
 #endif /* IHOP_WRITE_OUT */
   
@@ -375,9 +377,9 @@ CONTAINS
           ! allow space for at least MinNArr arrivals
           MaxNArr = MAX( ArrivalsStorage / ( NRz_per_range * Pos%NRr ), MinNArr )
 #ifdef IHOP_WRITE_OUT
-          WRITE( msgBuf,'(A)' ) 
+          WRITE(msgBuf,'(A)') 
           CALL PRINT_MESSAGE(msgBuf, PRTFile, SQUEEZE_RIGHT, myThid)
-          WRITE( msgBuf,'(A,I,A)' ) 'Max. # of arrivals = ', MaxNArr
+          WRITE(msgBuf,'(A,I10)') 'Max. # of arrivals = ', MaxNArr
           CALL PRINT_MESSAGE(msgBuf, PRTFile, SQUEEZE_RIGHT, myThid)
 #endif /* IHOP_WRITE_OUT */
   
@@ -488,15 +490,15 @@ CONTAINS
                 SELECT CASE ( Beam%Type( 1 : 1 ) )
                 CASE ( 'g' )
                    CALL InfluenceGeoHatRayCen(    U, Angles%alpha( ialpha ), &
-                                                  Angles%Dalpha )
+                                                  Angles%Dalpha, myThid )
                 CASE ( 'S' )
                    CALL InfluenceSGB( U, Angles%alpha( ialpha ), Angles%Dalpha )
                 CASE ( 'B' )
                    CALL InfluenceGeoGaussianCart( U, Angles%alpha( ialpha ), &
-                                                  Angles%Dalpha )
+                                                  Angles%Dalpha, myThid )
                CASE DEFAULT !IEsco22: thesis is in default behavior
                    CALL InfluenceGeoHatCart(  U, Angles%alpha( ialpha ), &
-                                              Angles%Dalpha )
+                                              Angles%Dalpha, myThid )
                 END SELECT
              END IF
   

--- a/ihop/bellhop.F90
+++ b/ihop/bellhop.F90
@@ -983,8 +983,7 @@ CONTAINS
 #ifdef IHOP_WRITE_OUT
        WRITE(msgBuf,'(2A)') 'HS%BC = ', HS%BC
        CALL PRINT_MESSAGE(msgBuf, PRTFile, SQUEEZE_RIGHT, myThid)
-       WRITE(msgBuf,'(2A)') 'BELLHOP Reflect2D: ', & 
-                            'Unknown boundary condition type'
+       WRITE(msgBuf,'(A)') 'BELLHOP Reflect2D: Unknown boundary condition type'
        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
        STOP 'ABNORMAL END: S/R Reflect2D'

--- a/ihop/ihop_driver.F
+++ b/ihop/ihop_driver.F
@@ -59,7 +59,6 @@ CEOP
 
 #ifdef ALLOW_IHOP
       IF ( ihop_iter .EQ. myIter ) THEN
-C      WRITE( errorMessageUnit, * ) 'Escobar: in IHOP_DRIVER:', myTime
        CALL IHOP_INIT( myThid )
       ENDIF
 #endif /* ALLOW_IHOP */

--- a/ihop/ihop_init_fixed.F
+++ b/ihop/ihop_init_fixed.F
@@ -48,9 +48,9 @@ CC ==================== External Functions ==========================
 C      INTEGER ILNBLNK
 C      EXTERNAL ILNBLNK
 CC---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
-CC Only do I/O if in the main thread
-C      _BEGIN_MASTER( myThid )
-C
+C Only do I/O if in the main thread
+       _BEGIN_MASTER( myThid )
+ 
 CC Read NetCDF input: setting the acoustic domain
 C      IL  = ILNBLNK( IHOP_interpfile )
 C      IF (IL.NE.0) THEN
@@ -124,9 +124,7 @@ C     &  'NetCDF ERROR: Cannot close file ', IHOP_interpfile(1:IL)
 C        CALL PRINT_ERROR( msgBuf, myThid )
 C        STOP 'ABNORMAL END: S/R IHOP_INIT_FIXED'
 C      END IF
-C
-CC Only do I/O if in the main thread
-C      _END_MASTER( myThid )
+
 
 C 'reshape' ihop_v_* arrays to 2D arrays
       k=1
@@ -138,6 +136,8 @@ C 'reshape' ihop_v_* arrays to 2D arrays
         k = k+1
        END DO
       END DO
+C Only do I/O if in the main thread
+      _END_MASTER( myThid )
 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 

--- a/ihop/influence.F90
+++ b/ihop/influence.F90
@@ -44,11 +44,18 @@ MODULE influence
   COMPLEX (KIND=_RL90), PRIVATE :: delay
 
 CONTAINS
-  SUBROUTINE InfluenceGeoHatRayCen( U, alpha, dalpha )
+  SUBROUTINE InfluenceGeoHatRayCen( U, alpha, dalpha, myThid )
 
     ! Geometrically-spreading beams with a hat-shaped beam in ray-centered 
     ! coordinates
 
+  !     == Routine Arguments ==
+  !     myThid :: Thread number. Unused by IESCO
+  !     msgBuf :: Used to build messages for printing.
+    INTEGER, INTENT( IN )   :: myThid
+    CHARACTER*(MAX_LEN_MBUF):: msgBuf
+  
+  !     == Local Variables ==
     REAL (KIND=_RL90), INTENT( IN    ) :: alpha, dalpha ! take-off angle radians
     COMPLEX,           INTENT( INOUT ) :: U( NRz_per_range, Pos%NRr )   ! complex pressure field
     INTEGER              :: irA, irB, II
@@ -171,10 +178,17 @@ CONTAINS
 
   ! **********************************************************************!
 
-  SUBROUTINE InfluenceGeoHatCart( U, alpha, Dalpha )
+  SUBROUTINE InfluenceGeoHatCart( U, alpha, Dalpha, myThid )
 
     ! Geometric, hat-shaped beams in Cartesisan coordinates
 
+  !     == Routine Arguments ==
+  !     myThid :: Thread number. Unused by IESCO
+  !     msgBuf :: Used to build messages for printing.
+    INTEGER, INTENT( IN )   :: myThid
+    CHARACTER*(MAX_LEN_MBUF):: msgBuf
+  
+  !     == Local Variables ==
     REAL (KIND=_RL90), INTENT( IN    ) :: alpha, & ! take-off angle, radians
                                           Dalpha   ! angular spacing
     COMPLEX,           INTENT( INOUT ) :: U( NRz_per_range, Pos%NRr ) ! complex pressure field
@@ -262,7 +276,8 @@ CONTAINS
 
                 IF ( n < RadiusMax ) THEN
 #ifdef IHOP_WRITE_OUT
-                   WRITE( PRTFile, * ) "influence: Eigenray w/ RadiusMax = ", RadiusMax
+                    WRITE(msgBuf,'(A,F10.2)') "Influence: Eigenray w RadiusMax = ", RadiusMax
+                    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
                    ! interpolated delay
                    delay    = ray2D( iS-1 )%tau + s*dtauds              
@@ -305,11 +320,18 @@ CONTAINS
 
   ! **********************************************************************!
 
-  SUBROUTINE InfluenceGeoGaussianCart( U, alpha, Dalpha )
+  SUBROUTINE InfluenceGeoGaussianCart( U, alpha, Dalpha, myThid )
 
     ! Geometric, Gaussian beams in Cartesian coordintes
     
     ! beam window: kills beams outside e**(-0.5 * ibwin**2 )
+  !     == Routine Arguments ==
+  !     myThid :: Thread number. Unused by IESCO
+  !     msgBuf :: Used to build messages for printing.
+    INTEGER, INTENT( IN )   :: myThid
+    CHARACTER*(MAX_LEN_MBUF):: msgBuf
+  
+  !     == Local Variables ==
     INTEGER,           PARAMETER       :: BeamWindow = 4 
     REAL (KIND=_RL90), INTENT( IN    ) :: alpha, dalpha ! take-off angle, angular spacing
     COMPLEX,           INTENT( INOUT ) :: U( NRz_per_range, Pos%NRr )  ! complex pressure field

--- a/ihop/mitgcm_code/EESUPPORT.h
+++ b/ihop/mitgcm_code/EESUPPORT.h
@@ -1,0 +1,296 @@
+!BOP
+!     !ROUTINE: EESUPPORT.h
+!     !INTERFACE:
+!     include "EESUPPORT.h"
+!
+!     !DESCRIPTION:
+!     *==========================================================*
+!     | EESUPPORT.h                                              |
+!     *==========================================================*
+!     | Support data structures for the MITgcm UV                |
+!     | "execution environment" code. This data should be        |
+!     | private to the execution environment routines. Data      |
+!     | which needs to be accessed directly by a numerical model |
+!     | goes in EEPARAMS.h.                                      |
+!     *==========================================================*
+!EOP
+
+!     ERROR_HEADER        - String which prefixes error messages
+      CHARACTER*(*) ERROR_HEADER
+      PARAMETER ( ERROR_HEADER = ' *** ERROR ***' )
+!     PROCESS_HEADER      - String which prefixes processor number
+      CHARACTER*(*) PROCESS_HEADER
+      PARAMETER ( PROCESS_HEADER = 'PID.TID' )
+
+!     MAX_NUM_COMM_MODES - Maximum number of communication modes
+!     COMM_NONE       - No edge communication
+!     COMM_MSG        - Use messages to communicate edges
+!     COMM_PUT        - Use put to communicate edges
+!     COMM_GET        - Use get to communicate edges
+!     Note - commName holds an identifying name for each communication
+!            mode. The COMM_ parameters are used to index commName
+!            so the COMM_ parameters need to be in the range
+!            1 : MAX_NUM_COMM_MODES.
+      INTEGER MAX_NUM_COMM_MODES
+      PARAMETER ( MAX_NUM_COMM_MODES = 4 )
+      INTEGER COMM_NONE
+      PARAMETER ( COMM_NONE   =   1 )
+      INTEGER COMM_MSG
+      PARAMETER ( COMM_MSG    =   2 )
+      INTEGER COMM_PUT
+      PARAMETER ( COMM_PUT    =   3 )
+      INTEGER COMM_GET
+      PARAMETER ( COMM_GET    =   4 )
+      COMMON /EESUPP_COMMNAME/ commName
+      CHARACTER*10 commName(MAX_NUM_COMM_MODES)
+
+!     Tile identifiers
+!     Tiles have a number that is unique over the global domain.
+!     A tile that is not there has its number set to NULL_TILE
+      INTEGER NULL_TILE
+      PARAMETER ( NULL_TILE = -1 )
+
+
+!--   COMMON /EESUPP_C/ Execution environment support character variables
+!     myProcessStr - String identifying my process number
+      COMMON /EESUPP_C/ myProcessStr
+      CHARACTER*128 myProcessStr
+
+!--   COMMON /EESUPP_L/ Execution environment support logical variables
+!     initMPError - Flag indicating error during multi-processing
+!                   initialisation.
+!     finMPError  - Flag indicating error during multi-processing
+!                   termination.
+!     ThError     - Thread detected an error.
+!     usingMPI    - Flag controlling use of MPI routines. This flag
+!                   allows either MPI or threads to be used in a
+!                   shared memory environment which can be a useful
+!                   debugging/performance analysis tool.
+!     usingSyncMessages - Flag that causes blocking communication to be used
+!                         if possible. When false non-blocking EXCH routines
+!                         will be used if possible.
+!     notUsingXPeriodicity - Flag indicating no X/Y boundary wrap around
+!     notUsingYPeriodicity   This affects the communication routines but
+!                            is generally ignored in the numerical model
+!                            code.
+!     threadIsRunning, threadIsComplete - Flags used to check for correct behaviour
+!                                         of multi-threaded code.
+!                                         threadIsRunning is used to check that the
+!                                         threads we need are running. This catches the
+!                                         situation where a program eedata file has nTthreads
+!                                         greater than the setenv PARALLEL or NCPUS variable.
+!                                         threadIsComplete is used to flag that a thread has
+!                                         reached the end of the model. This is used as a check to
+!                                         trap problems that might occur if one thread "escapes"
+!                                         the main.F master loop. This should not happen
+!                                         if the multi-threading compilation tools works right.
+!                                         But (see for example KAP) this is not always the case!
+      COMMON /EESUPP_L/ thError, threadIsRunning, threadIsComplete,                                                                     &
+     & allMyEdgesAreSharedMemory, usingMPI, usingSyncMessages,                                                                          &
+     & notUsingXPeriodicity, notUsingYPeriodicity
+      LOGICAL thError(MAX_NO_THREADS)
+      LOGICAL threadIsRunning(MAX_NO_THREADS)
+      LOGICAL threadIsComplete(MAX_NO_THREADS)
+      LOGICAL allMyEdgesAreSharedMemory(MAX_NO_THREADS)
+      LOGICAL usingMPI
+      LOGICAL usingSyncMessages
+      LOGICAL notUsingXPeriodicity
+      LOGICAL notUsingYPeriodicity
+
+!--   COMMON /EESUPP_I/ Parallel support integer globals
+!     pidW   -  Process  ID of neighbor to West
+!     pidE   -           ditto             East
+!     pidN   -           ditto             North
+!     pidS   -           ditto             South
+!              Note: pid[XY] is not necessairily the UNIX
+!                    process id - it is just an identifying
+!                    number.
+!     myPid  - My own process id
+!     nProcs - Number of processes
+!     westCommunicationMode  - Mode of communication for each tile face
+!     eastCommunicationMode
+!     northCommunicationMode
+!     southCommunicationMode
+!     bi0   - Low cartesian tile index for this process
+!     bj0     Note - In a tile distribution with holes bi0 and bj0
+!                    are not useful. Neighboring tile indices must
+!                    be derived some other way.
+!     tileNo       - Tile identification number for my tile and
+!     tileNo[WENS]   my N,S,E,W neighbor tiles.
+!     tilePid[WENS] - Process identification number for
+!                     my N,S,E,W neighbor tiles.
+!     nTx, nTy    - No. threads in X and Y. This assumes a simple
+!                   cartesian gridding of the threads which is not
+!                   required elsewhere but that makes it easier.
+      COMMON /EESUPP_I/                                                                                                                 &
+     & myPid, nProcs, pidW, pidE, pidN, pidS,                                                                                           &
+     & tileCommModeW,  tileCommModeE,                                                                                                   &
+     & tileCommModeN,  tileCommModeS,                                                                                                   &
+     & tileNo, tileNoW, tileNoE, tileNoS, tileNoN,                                                                                      &
+     &  tilePidW, tilePidE, tilePidS, tilePidN,                                                                                         &
+     &  tileBiW, tileBiE, tileBiS, tileBiN,                                                                                             &
+     & tileBjW, tileBjE, tileBjS, tileBjN,                                                                                              &
+     & tileTagSendW, tileTagSendE, tileTagSendS, tileTagSendN,                                                                          &
+     & tileTagRecvW, tileTagRecvE, tileTagRecvS, tileTagRecvN
+      INTEGER myPid
+      INTEGER nProcs
+      INTEGER pidW
+      INTEGER pidE
+      INTEGER pidN
+      INTEGER pidS
+      INTEGER tileCommModeW ( nSx, nSy )
+      INTEGER tileCommModeE ( nSx, nSy )
+      INTEGER tileCommModeN ( nSx, nSy )
+      INTEGER tileCommModeS ( nSx, nSy )
+      INTEGER tileNo( nSx, nSy )
+      INTEGER tileNoW( nSx, nSy )
+      INTEGER tileNoE( nSx, nSy )
+      INTEGER tileNoN( nSx, nSy )
+      INTEGER tileNoS( nSx, nSy )
+      INTEGER tilePidW( nSx, nSy )
+      INTEGER tilePidE( nSx, nSy )
+      INTEGER tilePidN( nSx, nSy )
+      INTEGER tilePidS( nSx, nSy )
+      INTEGER tileBiW( nSx, nSy )
+      INTEGER tileBiE( nSx, nSy )
+      INTEGER tileBiN( nSx, nSy )
+      INTEGER tileBiS( nSx, nSy )
+      INTEGER tileBjW( nSx, nSy )
+      INTEGER tileBjE( nSx, nSy )
+      INTEGER tileBjN( nSx, nSy )
+      INTEGER tileBjS( nSx, nSy )
+      INTEGER tileTagSendW( nSx, nSy )
+      INTEGER tileTagSendE( nSx, nSy )
+      INTEGER tileTagSendN( nSx, nSy )
+      INTEGER tileTagSendS( nSx, nSy )
+      INTEGER tileTagRecvW( nSx, nSy )
+      INTEGER tileTagRecvE( nSx, nSy )
+      INTEGER tileTagRecvN( nSx, nSy )
+      INTEGER tileTagRecvS( nSx, nSy )
+
+#ifdef ALLOW_USE_MPI
+!--   Include MPI standard Fortran header file
+#include "mpif.h"
+#define _mpiTRUE_  1
+#define _mpiFALSE_ 0
+
+!--   COMMON /EESUPP_MPI_I/ MPI parallel support integer globals
+!     mpiPidW   - MPI process id for west neighbor.
+!     mpiPidE   - MPI process id for east neighbor.
+!     mpiPidN   - MPI process id for north neighbor.
+!     mpiPidS   - MPI process id for south neighbor.
+!     mpiPidNW  - MPI process id for northwest neighbor.
+!     mpiPidNE  - MPI process id for northeast neighbor.
+!     mpiPidSW  - MPI process id for southwest neighbor.
+!     mpiPidSE  - MPI process id for southeast neighbor.
+!     mpiPidIO  - MPI process to use for IO.
+!     mpiNprocs - No. of MPI processes.
+!     mpiMyId   - MPI process id of me.
+!     mpiComm   - MPI communicator to use.
+!     mpiPx     - My MPI proc. grid X coord
+!     mpiPy     - My MPI proc. grid Y coord
+!     mpiXGlobalLo - My bottom-left (south-west) x-coordinate in
+!                    global domain.
+!     mpiYGlobalLo - My bottom-left (south-west) y-coordinate in
+!                    global domain.
+!     mpiTypeXFaceBlock_xy_r4  - Primitives for communicating edge
+!     mpiTypeXFaceBlock_xy_r8    of a block.
+!     mpiTypeYFaceBlock_xy_r4    XFace is used in east-west transfer
+!     mpiTypeYFaceBlock_xy_r8    YFace is used in nrth-south transfer
+!     mpiTypeXFaceBlock_xyz_r4   xy is used in two-dimensional arrays
+!     mpiTypeXFaceBlock_xyz_r8   xyz is used with three-dimensional arrays
+!     mpiTypeYFaceBlock_xyz_r4   r4 is used for real*4 data
+!     mpiTypeYFaceBlock_xyz_r8   r8 is used for real*8 data
+!     mpiTypeXFaceThread_xy_r4  - Composites of the above primitives
+!     mpiTypeXFaceThread_xy_r8    for communicating edges of all blocks
+!     mpiTypeYFaceThread_xy_r4    owned by a thread.
+!     mpiTypeYFaceThread_xy_r8
+!     mpiTypeXFaceThread_xyz_r4
+!     mpiTypeXFaceThread_xyz_r8
+!     mpiTypeYFaceThread_xyz_r4
+!     mpiTypeYFaceBlock_xyz_r8
+!     mpiTagE       - Tags are needed to mark requests when MPI is running
+!     mpiTagW         between multithreaded processes or when the same process.
+!     mpiTagS         is a neighbor in more than one direction. The tags ensure that
+!     mpiTagN         a thread will get the message it is looking for.
+!     mpiTagSW        The scheme adopted is to tag messages according to
+!     mpiTagSE        the direction they are travelling. Thus a message
+!     mpiTagNW        travelling east is tagged mpiTagE. However, in a
+!     mpiTagNE        multi-threaded environemnt several messages could
+!                     be travelling east from the same process at the
+!                     same time. The tag is therefore modified to
+!                     be mpiTag[EWS...]*nThreads+myThid. This requires that
+!                     each thread also know the thread ids of its "neighbor"
+!                     threads.
+      COMMON /EESUPP_MPI_I/                                                                                                             &
+     & mpiPidW,  mpiPidE,  mpiPidS,  mpiPidN,                                                                                           &
+     & mpiPidSE, mpiPidSW, mpiPidNE, mpiPidNW,                                                                                          &
+     & mpiPidIo, mpiMyId, mpiNProcs, mpiComm,                                                                                           &
+     & mpiPx, mpiPy, mpiXGlobalLo, mpiYGlobalLo,                                                                                        &
+     & mpiTypeXFaceBlock_xy_r4, mpiTypeXFaceBlock_xy_r8,                                                                                &
+     & mpiTypeYFaceBlock_xy_r4, mpiTypeYFaceBlock_xy_r8,                                                                                &
+     & mpiTypeXFaceBlock_xyz_r4, mpiTypeXFaceBlock_xyz_r8,                                                                              &
+     & mpiTypeYFaceBlock_xyz_r4, mpiTypeYFaceBlock_xyz_r8,                                                                              &
+     & mpiTypeXFaceThread_xy_r4, mpiTypeXFaceThread_xy_r8,                                                                              &
+     & mpiTypeYFaceThread_xy_r4, mpiTypeYFaceThread_xy_r8,                                                                              &
+     & mpiTypeXFaceThread_xyz_r4, mpiTypeXFaceThread_xyz_r8,                                                                            &
+     & mpiTypeYFaceThread_xyz_r4, mpiTypeYFaceThread_xyz_r8,                                                                            &
+     & mpiTagE, mpiTagW, mpiTagN, mpiTagS,                                                                                              &
+     & mpiTagSE, mpiTagSW, mpiTagNW, mpiTagNE
+
+      INTEGER mpiPidW
+      INTEGER mpiPidE
+      INTEGER mpiPidS
+      INTEGER mpiPidN
+      INTEGER mpiPidSW
+      INTEGER mpiPidSE
+      INTEGER mpiPidNW
+      INTEGER mpiPidNE
+      INTEGER mpiPidIO
+      INTEGER mpiMyId
+      INTEGER mpiNProcs
+      INTEGER mpiComm
+      INTEGER mpiPx
+      INTEGER mpiPy
+      INTEGER mpiXGlobalLo
+      INTEGER mpiYGlobalLo
+      INTEGER mpiTypeXFaceBlock_xy_r4
+      INTEGER mpiTypeXFaceBlock_xy_r8
+      INTEGER mpiTypeYFaceBlock_xy_r4
+      INTEGER mpiTypeYFaceBlock_xy_r8
+      INTEGER mpiTypeXFaceBlock_xyz_r4
+      INTEGER mpiTypeXFaceBlock_xyz_r8
+      INTEGER mpiTypeYFaceBlock_xyz_r4
+      INTEGER mpiTypeYFaceBlock_xyz_r8
+      INTEGER mpiTypeXFaceThread_xy_r4(MAX_NO_THREADS)
+      INTEGER mpiTypeXFaceThread_xy_r8(MAX_NO_THREADS)
+      INTEGER mpiTypeYFaceThread_xy_r4(MAX_NO_THREADS)
+      INTEGER mpiTypeYFaceThread_xy_r8(MAX_NO_THREADS)
+      INTEGER mpiTypeXFaceThread_xyz_r4(MAX_NO_THREADS)
+      INTEGER mpiTypeXFaceThread_xyz_r8(MAX_NO_THREADS)
+      INTEGER mpiTypeYFaceThread_xyz_r4(MAX_NO_THREADS)
+      INTEGER mpiTypeYFaceThread_xyz_r8(MAX_NO_THREADS)
+      INTEGER mpiTagNW
+      INTEGER mpiTagNE
+      INTEGER mpiTagSW
+      INTEGER mpiTagSE
+      INTEGER mpiTagW
+      INTEGER mpiTagE
+      INTEGER mpiTagN
+      INTEGER mpiTagS
+
+!--   COMMON /MPI_FULLMAP_I/ holds integer arrays of the full list of MPI process
+!     mpi_myXGlobalLo :: List of all processors bottom-left X-index in global domain
+!     mpi_myYGlobalLo :: List of all processors bottom-left Y-index in global domain
+!                        Note: needed for mpi gather/scatter routines & singleCpuIO.
+      COMMON /MPI_FULLMAP_I/                                                                                                            &
+     &        mpi_myXGlobalLo, mpi_myYGlobalLo
+      INTEGER mpi_myXGlobalLo(nPx*nPy)
+      INTEGER mpi_myYGlobalLo(nPx*nPy)
+
+! MPI communicator describing this model realization
+      COMMON /MPI_COMMS/                                                                                                                &
+     &        MPI_COMM_MODEL
+      INTEGER MPI_COMM_MODEL
+
+#endif /* ALLOW_USE_MPI */

--- a/ihop/mitgcm_code/forward_step.F
+++ b/ihop/mitgcm_code/forward_step.F
@@ -1105,11 +1105,6 @@ CADJ STORE pTracer     = comlev1, key = ikey_dynamics, kind = isbyte
       ENDIF
 #endif /* ALLOW_GCHEM */
 
-#ifdef ALLOW_IHOP
-      CALL IHOP_SOUND_SPEED( myThid )
-      CALL IHOP_DRIVER( myTime,myIter,myThid )
-#endif /* ALLOW_IHOP */
-
 C--   Do "blocking" sends and receives for tendency "overlap" terms
 c     CALL TIMER_START('BLOCKING_EXCHANGES  [FORWARD_STEP]',myThid)
 c     CALL DO_GTERM_BLOCKING_EXCHANGES( myThid )
@@ -1130,6 +1125,12 @@ CADJ STORE totPhiHyd   = comlev1, key = ikey_dynamics, kind = isbyte
 CADJ STORE pTracer     = comlev1, key = ikey_dynamics, kind = isbyte
 # endif
 #endif
+
+#ifdef ALLOW_IHOP
+C--   Acoustical physics
+      CALL IHOP_SOUND_SPEED( myThid )
+      CALL IHOP_DRIVER( myTime,myIter,myThid )
+#endif /* ALLOW_IHOP */
 
 #ifdef ALLOW_DIAGNOSTICS
       IF ( useDiagnostics ) THEN

--- a/ihop/mitgcm_input/data.diagnostics
+++ b/ihop/mitgcm_input/data.diagnostics
@@ -1,7 +1,7 @@
  &DIAGNOSTICS_LIST
   fileName(1)     = 'diags/ssp',
   fields(1:1,1)   = 'ihop_ssp',
-  frequency(1)    = 6400.,
+  frequency(1)    = 1200.,
  &
 
  &DIAG_STATIS_PARMS

--- a/ihop/readenvihop.F90
+++ b/ihop/readenvihop.F90
@@ -72,8 +72,9 @@ CONTAINS
 
     ! *** TITLE ***
 #ifdef IHOP_THREED
-    WRITE(errorMessageUnit,'(2A)') 'READENVIHOP ReadEnvironment: ', & 
+    WRITE(msgBuf,'(2A)') 'READENVIHOP ReadEnvironment: ', & 
                          '3D not supported in ihop'
+    CALL PRINT_ERROR( msgBuf,myThid )
     STOP 'ABNORMAL END: S/R ReadEnvironment'
     Title( 1 :11 ) = 'iHOP3D - '
     Title( 12:80 ) = IHOP_title
@@ -145,8 +146,9 @@ CONTAINS
     CASE( ' ' )
     CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
-        WRITE(errorMessageUnit,'(2A)') 'READENVIHOP ReadEnvironment: ', & 
+        WRITE(msgBuf,'(2A)') 'READENVIHOP ReadEnvironment: ', & 
                              'Unknown bottom option letter in second position'
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
         STOP 'ABNORMAL END: S/R ReadEnvironment'
     END SELECT
@@ -197,8 +199,9 @@ CONTAINS
 
     ! Limits for tracing beams
 #ifdef IHOP_THREED
-    WRITE(errorMessageUnit,'(2A)') 'READENVIHOP ReadEnvironment: ', & 
+    WRITE(msgBuf,'(2A)') 'READENVIHOP ReadEnvironment: ', & 
                          '3D not supported in ihop'
+    CALL PRINT_ERROR( msgBuf,myThid )
     STOP 'ABNORMAL END: S/R ReadEnvironment'
     !READ(  ENVFile, * ) Beam%deltas, Beam%Box%x, Beam%Box%y, Beam%Box%z
     Beam%Box%x = 1000.0 * Beam%Box%x   ! convert km to m
@@ -340,8 +343,9 @@ CONTAINS
 #endif /* IHOP_WRITE_OUT */
           CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
-                WRITE(errorMessageUnit,'(2A)') 'READENVIHOP ReadEnvironment: ', & 
+                WRITE(msgBuf,'(2A)') 'READENVIHOP ReadEnvironment: ', & 
                                      'Unknown curvature condition'
+                CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
                 STOP 'ABNORMAL END: S/R ReadEnvironment'
           END SELECT
@@ -364,8 +368,9 @@ CONTAINS
 #endif /* IHOP_WRITE_OUT */
        CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
-            WRITE(errorMessageUnit,'(2A)') 'READENVIHOP ReadEnvironment: ', & 
+            WRITE(msgBuf,'(2A)') 'READENVIHOP ReadEnvironment: ', & 
                                 'Unknown beam type (second letter of run type)'
+            CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
             STOP 'ABNORMAL END: S/R ReadEnvironment'
        END SELECT
@@ -442,8 +447,9 @@ CONTAINS
 #endif /* IHOP_WRITE_OUT */
     CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
-        WRITE(errorMessageUnit,'(2A)') 'READENVIHOP ReadTopOpt: ', & 
+        WRITE(msgBuf,'(2A)') 'READENVIHOP ReadTopOpt: ', & 
                              'Unknown option for SSP approximation'
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
         STOP 'ABNORMAL END: S/R ReadTopOpt'
     END SELECT
@@ -483,8 +489,9 @@ CONTAINS
 #endif /* IHOP_WRITE_OUT */
     CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
-        WRITE(errorMessageUnit,'(2A)') 'READENVIHOP ReadTopOpt: ', & 
+        WRITE(msgBuf,'(2A)') 'READENVIHOP ReadTopOpt: ', & 
                              'Unknown attenuation units'
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
         STOP 'ABNORMAL END: S/R ReadTopOpt'
     END SELECT
@@ -531,8 +538,9 @@ CONTAINS
     CASE ( ' ' )
     CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
-        WRITE(errorMessageUnit,'(2A)') 'READENVIHOP ReadTopOpt: ', & 
+        WRITE(msgBuf,'(2A)') 'READENVIHOP ReadTopOpt: ', & 
                              'Unknown top option letter in fourth position'
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
         STOP 'ABNORMAL END: S/R ReadTopOpt'
     END SELECT
@@ -546,8 +554,9 @@ CONTAINS
     CASE ( '-', '_', ' ' )
     CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
-        WRITE(errorMessageUnit,'(2A)') 'READENVIHOP ReadTopOpt: ', & 
+        WRITE(msgBuf,'(2A)') 'READENVIHOP ReadTopOpt: ', & 
                              'Unknown top option letter in fifth position'
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
         STOP 'ABNORMAL END: S/R ReadTopOpt'
     END SELECT
@@ -561,8 +570,9 @@ CONTAINS
     CASE ( ' ' )
     CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
-        WRITE(errorMessageUnit,'(2A)') 'READENVIHOP ReadTopOpt: ', & 
+        WRITE(msgBuf,'(2A)') 'READENVIHOP ReadTopOpt: ', & 
                              'Unknown top option letter in sixth position'
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
         STOP 'ABNORMAL END: S/R ReadTopOpt'
     END SELECT
@@ -631,8 +641,9 @@ CONTAINS
 #endif /* IHOP_WRITE_OUT */
     CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
-        WRITE(errorMessageUnit,'(2A)') 'READENVIHOP ReadRunType: ', & 
+        WRITE(msgBuf,'(2A)') 'READENVIHOP ReadRunType: ', & 
             'Unknown RunType selected'
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
         STOP 'ABNORMAL END: S/R ReadRunType'
     END SELECT
@@ -710,8 +721,9 @@ CONTAINS
 #endif /* IHOP_WRITE_OUT */
        IF ( Pos%NRz /= Pos%NRr ) THEN
 #ifdef IHOP_WRITE_OUT
-            WRITE(errorMessageUnit,'(2A)') 'READENVIHOP ReadRunType: ', & 
+            WRITE(msgBuf,'(2A)') 'READENVIHOP ReadRunType: ', & 
                     'Irregular grid option selected with NRz not equal to Nr'
+            CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
             STOP 'ABNORMAL END: S/R ReadRunType'
        END IF
@@ -802,8 +814,9 @@ CONTAINS
 #endif /* IHOP_WRITE_OUT */
     CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
-        WRITE(errorMessageUnit,'(2A)') 'READENVIHOP TopBot: ', & 
+        WRITE(msgBuf,'(2A)') 'READENVIHOP TopBot: ', & 
                              'Unknown boundary condition type'
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
         STOP 'ABNORMAL END: S/R TopBot'
     END SELECT

--- a/ihop/readenvihop.F90
+++ b/ihop/readenvihop.F90
@@ -359,9 +359,9 @@ CONTAINS
           ! Images, windows
           WRITE(msgBuf,'(A)') 
           CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-          WRITE(msgBuf,'(A,I)') 'Number of images, Nimage  = ', Beam%Nimage
+          WRITE(msgBuf,'(A,I10)') 'Number of images, Nimage  = ', Beam%Nimage
           CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-          WRITE(msgBuf,'(A,I)') 'Beam windowing parameter  = ', Beam%iBeamWindow
+          WRITE(msgBuf,'(A,I10)') 'Beam windowing parameter  = ', Beam%iBeamWindow
           CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
           WRITE(msgBuf,'(A)') 'Component                 = ', Beam%Component
           CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
@@ -516,7 +516,7 @@ CONTAINS
 #ifdef IHOP_WRITE_OUT
        WRITE(msgBuf,'(A)') '    Biological attenaution'
        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-       WRITE(msgBuf,'(A,I)') '      Number of Bio Layers = ', NBioLayers
+       WRITE(msgBuf,'(A,I10)') '      Number of Bio Layers = ', NBioLayers
        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 
        DO iBio = 1, NBioLayers

--- a/ihop/readenvihop.F90
+++ b/ihop/readenvihop.F90
@@ -66,7 +66,7 @@ CONTAINS
 #ifdef IHOP_WRITE_OUT
     WRITE(msgbuf,'(A)') 'iHOP Print File'
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-    WRITE(msgbuf,'(A)') NEW_LINE('a')
+    WRITE(msgbuf,'(A)') 
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
 
@@ -84,6 +84,8 @@ CONTAINS
 
 #ifdef IHOP_WRITE_OUT
     WRITE(msgbuf,'(A)') Title
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    WRITE(msgbuf,'(A)')
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     WRITE( msgBuf, '(A,G11.4,A)' )'Frequency ', IHOP_freq, 'Hz'
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
@@ -106,7 +108,7 @@ CONTAINS
     x = [ 0.0 _d 0, Bdry%Bot%HS%Depth ]   ! tells SSP Depth to read to
 
 #ifdef IHOP_WRITE_OUT
-    WRITE(msgBuf,'(A)') NEW_LINE('a')
+    WRITE(msgBuf,'(A)') 
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     WRITE(msgBuf,'(A,F10.2,A)' ) 'Depth = ',Bdry%Bot%HS%Depth,' m'
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
@@ -128,7 +130,7 @@ CONTAINS
     ! bottom depth should perhaps be set the same way?
     Bdry%Bot%HS%Opt = IHOP_botopt 
 #ifdef IHOP_WRITE_OUT
-    WRITE(msgBuf,'(A)') NEW_LINE('a')
+    WRITE(msgBuf,'(A)') 
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     WRITE(msgBuf,'(2A)') 'Bottom options: ', Bdry%Bot%HS%Opt
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
@@ -184,12 +186,12 @@ CONTAINS
 #endif /* IHOP_THREED */
 
 #ifdef IHOP_WRITE_OUT
-    WRITE(msgBuf,'(A)') NEW_LINE('a')
+    WRITE(msgBuf,'(A)') 
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     WRITE(msgBuf,'(2A)')'___________________________________________________', &
-                        '_______________________'
+                        '________'
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-    WRITE(msgBuf,'(A)') NEW_LINE('a')
+    WRITE(msgBuf,'(A)') 
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
 
@@ -206,12 +208,12 @@ CONTAINS
     IF ( Beam%deltas == 0.0 ) Beam%deltas = &
         ( Bdry%Bot%HS%Depth - Bdry%Top%HS%Depth ) / 10.0   
 #ifdef IHOP_WRITE_OUT
-    WRITE(msgBuf,'(A)') NEW_LINE('a')
+    WRITE(msgBuf,'(A)') 
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-    WRITE(msgBuf,'(A,T5,A,G11.4,A)') &
-        ' Step length', 'deltas = ', Beam%deltas, ' m'
+    WRITE(msgBuf,'(A,A,G11.4,A)') &
+        ' Step length,', ' deltas = ', Beam%deltas, ' m'
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-    WRITE(msgBuf,'(A)') NEW_LINE('a')
+    WRITE(msgBuf,'(A)') 
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     WRITE(msgBuf,'(A,G11.4,A)') &
         ' Maximum ray x-range, Box%X = ', Beam%Box%X,' m'
@@ -238,19 +240,19 @@ CONTAINS
     IF ( Beam%deltas == 0.0 ) THEN ! Automatic step size option
         Beam%deltas = ( Bdry%Bot%HS%Depth - Bdry%Top%HS%Depth ) / 10.0   
 #ifdef IHOP_WRITE_OUT
-        WRITE(msgBuf,'(A)') NEW_LINE('a')
+        WRITE(msgBuf,'(A)') 
         CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-        WRITE(msgBuf,'(A,T5,A,G11.4,A)') &
-            ' Step length', 'deltas = ', Beam%deltas, ' m (automatic step)'
+        WRITE(msgBuf,'(A,A,G11.4,A)') &
+            ' Step length,', ' deltas = ', Beam%deltas, ' m (automatic step)'
         CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     ELSE
-        WRITE(msgBuf,'(A,T5,A,G11.4,A)') &
-            ' Step length', 'deltas = ', Beam%deltas, ' m'
+        WRITE(msgBuf,'(A,A,G11.4,A)') &
+            ' Step length,', ' deltas = ', Beam%deltas, ' m'
         CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
     END IF
 #ifdef IHOP_WRITE_OUT
-    WRITE(msgBuf,'(A)') NEW_LINE('a')
+    WRITE(msgBuf,'(A)') 
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     WRITE(msgBuf,'(A,G11.4,A)') &
         ' Maximum ray range, Box%R = ', Beam%Box%R,' km'
@@ -269,10 +271,10 @@ CONTAINS
 #ifdef IHOP_WRITE_OUT
        SELECT CASE ( Beam%Type( 4 : 4 ) )
        CASE ( 'S' )
-          WRITE(msgBuf,'(A)') 'Beam shift in effect'
+          WRITE(msgBuf,'(A)') ' Beam shift in effect'
           CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
        CASE DEFAULT
-          WRITE(msgBuf,'(A)') 'No beam shift in effect'
+          WRITE(msgBuf,'(A)') ' No beam shift in effect'
           CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
        END SELECT
 #endif /* IHOP_WRITE_OUT */
@@ -312,9 +314,9 @@ CONTAINS
        CASE ( 'R', 'C' )   
           !READ(  ENVFile, * ) Beam%Type( 2 : 3 ), Beam%epsMultiplier, Beam%rLoop
 #ifdef IHOP_WRITE_OUT
-          WRITE(msgBuf,'(A)') NEW_LINE('a')
+          WRITE(msgBuf,'(A)') 
           CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-          WRITE(msgBuf,'(A)') NEW_LINE('a')
+          WRITE(msgBuf,'(A)') 
           CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
           WRITE(msgBuf,'(2A)') 'Type of beam = ', Beam%Type( 1:1 )
           CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
@@ -351,7 +353,7 @@ CONTAINS
           CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 
           ! Images, windows
-          WRITE(msgBuf,'(A)') NEW_LINE('a')
+          WRITE(msgBuf,'(A)') 
           CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
           WRITE(msgBuf,'(A,I)') 'Number of images, Nimage  = ', Beam%Nimage
           CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
@@ -370,7 +372,7 @@ CONTAINS
     END IF
 
 #ifdef IHOP_WRITE_OUT
-    WRITE(msgBuf,'(A)') NEW_LINE('a')
+    WRITE(msgBuf,'(A)') 
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
 
@@ -397,7 +399,7 @@ CONTAINS
 
     TopOpt = IHOP_topopt
 #ifdef IHOP_WRITE_OUT
-    WRITE(msgBuf,'(A)') NEW_LINE('a')
+    WRITE(msgBuf,'(A)') 
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
 
@@ -587,7 +589,7 @@ CONTAINS
     CHARACTER (LEN=10), INTENT( OUT ) :: PlotType
 
 #ifdef IHOP_WRITE_OUT
-    WRITE(msgBuf,'(A)') NEW_LINE('a')
+    WRITE(msgBuf,'(A)') 
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
 
@@ -822,7 +824,7 @@ CONTAINS
        alphaI   = IHOP_bcsoundI
        betaI    = IHOP_bcsoundshearI
 #ifdef IHOP_WRITE_OUT
-       WRITE(msgBuf,'(A)') NEW_LINE('a')
+       WRITE(msgBuf,'(A)') 
        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
        WRITE(msgBuf,'(A)') &
         '   z (m)     alphaR (m/s)   betaR  rho (g/cm^3)  alphaI     betaI'

--- a/ihop/refcoef.F90
+++ b/ihop/refcoef.F90
@@ -43,10 +43,13 @@ CONTAINS
 
     ! Optionally read in reflection coefficient for Top or Bottom boundary
 
-    ! == Routine Arguments ==
-    ! myThid :: Thread number for this instance of the routine
-    INTEGER, INTENT(IN) :: myThid
-
+  !     == Routine Arguments ==
+  !     myThid :: Thread number. Unused by IESCO
+  !     msgBuf :: Used to build messages for printing.
+    INTEGER, INTENT( IN )   :: myThid
+    CHARACTER*(MAX_LEN_MBUF):: msgBuf
+  
+  !     == Local Variables ==
     CHARACTER (LEN=1 ), INTENT( IN ) :: BotRC, TopRC! flag set to 'F' if refl. coef. is to be read from a File
     CHARACTER (LEN=80), INTENT( IN ) :: FileRoot
     INTEGER            :: itheta, ik, IOStat, iAllocStat
@@ -64,9 +67,10 @@ CONTAINS
              IOSTAT = IOStat, ACTION = 'READ' )
        IF ( IOStat /= 0 ) THEN
 #ifdef IHOP_WRITE_OUT
-          WRITE( PRTFile, * ) 'BRCFile = ', TRIM( FileRoot ) // '.brc'
-          WRITE(errorMessageUnit,'(2A)') 'REFCOEF ReadReflectionCoeffcient: ', &
+            WRITE( PRTFile, * ) 'BRCFile = ', TRIM( FileRoot ) // '.brc'
+            WRITE(msgBuf,'(2A)')'REFCOEF ReadReflectionCoeffcient: ',&
                             'Unable to open Bottom Reflection Coefficient file'
+            CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
           STOP 'ABNORMAL END: S/R ReadReflectionCoefficient'
        END IF
@@ -81,8 +85,9 @@ CONTAINS
        ALLOCATE( RBot( NBotPts ), Stat = IAllocStat )
        IF ( IAllocStat /= 0 ) THEN
 #ifdef IHOP_WRITE_OUT
-          WRITE(errorMessageUnit,'(2A)') 'REFCOEF ReadReflectionCoeffcient: ', &
+        WRITE(msgBuf,'(2A)') 'REFCOEF ReadReflectionCoeffcient: ', &
                     'Insufficient memory for bot. refl. coef.: reduce # points'
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
           STOP 'ABNORMAL END: S/R ReadReflectionCoefficient'
        END IF
@@ -107,9 +112,10 @@ CONTAINS
              IOSTAT = IOStat, ACTION = 'READ' )
        IF ( IOStat /= 0 ) THEN
 #ifdef IHOP_WRITE_OUT
-          WRITE( PRTFile, * ) 'TRCFile = ', TRIM( FileRoot ) // '.trc'
-          WRITE(errorMessageUnit,'(2A)') 'REFCOEF ReadReflectionCoeffcient: ', &
+        WRITE( PRTFile, * ) 'TRCFile = ', TRIM( FileRoot ) // '.trc'
+        WRITE(msgBuf,'(2A)') 'REFCOEF ReadReflectionCoeffcient: ', &
                                'Unable to open Top Reflection Coefficient file'
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
           STOP 'ABNORMAL END: S/R ReadReflectionCoefficient'
        END IF
@@ -124,8 +130,9 @@ CONTAINS
        ALLOCATE( RTop( NTopPts ), Stat = IAllocStat )
        IF ( iAllocStat /= 0 ) THEN
 #ifdef IHOP_WRITE_OUT
-          WRITE(errorMessageUnit,'(2A)') 'REFCOEF ReadReflectionCoeffcient: ', &
+        WRITE(msgBuf,'(2A)') 'REFCOEF ReadReflectionCoeffcient: ', &
                     'Insufficient memory for top refl. coef.: reduce # points'
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
           STOP 'ABNORMAL END: S/R ReadReflectionCoefficient'
        END IF
@@ -147,8 +154,9 @@ CONTAINS
              IOSTAT = IOStat, ACTION = 'READ' )
        IF ( IOStat /= 0 ) THEN
 #ifdef IHOP_WRITE_OUT
-          WRITE(errorMessageUnit,'(2A)') 'REFCOEF ReadReflectionCoeffcient: ', &
+        WRITE(msgBuf,'(2A)') 'REFCOEF ReadReflectionCoeffcient: ', &
                         'Unable to open Internal Reflection Coefficient file'
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
           STOP 'ABNORMAL END: S/R ReadReflectionCoefficient'
        END IF
@@ -166,8 +174,9 @@ CONTAINS
                  Stat = iAllocStat )
        IF ( iAllocStat /= 0 ) THEN
 #ifdef IHOP_WRITE_OUT
-          WRITE(errorMessageUnit,'(2A)') 'REFCOEF ReadReflectionCoeffcient: ', &
+        WRITE(msgBuf,'(2A)') 'REFCOEF ReadReflectionCoeffcient: ', &
                                'Too many points in reflection coefficient'
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
           STOP 'ABNORMAL END: S/R ReadReflectionCoefficient'
        END IF

--- a/ihop/srpos_mod.F90
+++ b/ihop/srpos_mod.F90
@@ -76,11 +76,11 @@ CONTAINS
     IF ( BroadbandOption == 'B' ) THEN
 #ifdef IHOP_WRITE_OUT
         WRITE(msgBuf,'(2A)')'________________________________________________',&
-                            '__________________________'
+                            '___________'
         CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-        WRITE(msgBuf,'(A)') NEW_LINE('a')
+        WRITE(msgBuf,'(A)') 
         CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-        WRITE(msgBuf,'(A)') NEW_LINE('a')
+        WRITE(msgBuf,'(A)') 
         CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
         WRITE(msgBuf,'(A,I)') 'Number of frequencies =', Nfreq
         CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
@@ -331,14 +331,14 @@ CONTAINS
     INTEGER :: ix
    
 #ifdef IHOP_WRITE_OUT
-    WRITE(msgBuf,'(A)') NEW_LINE('a')
+    WRITE(msgBuf,'(A)') 
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     WRITE(msgBuf,'(2A)')'__________________________________________________', &
-                        '________________________'
+                        '_________'
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-    WRITE(msgBuf,'(A)') NEW_LINE('a')
+    WRITE(msgBuf,'(A)') 
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-    WRITE(msgBuf,'(A)') 'Number of ' // Description // ' = ', Nx
+    WRITE(msgBuf,'(A,I)') 'Number of ' // Description // ' = ', Nx
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
 
@@ -377,7 +377,7 @@ CONTAINS
         CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     END IF
 
-    WRITE(msgBuf,'(A)') NEW_LINE('a')
+    WRITE(msgBuf,'(A)') 
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
 

--- a/ihop/srpos_mod.F90
+++ b/ihop/srpos_mod.F90
@@ -60,10 +60,13 @@ CONTAINS
     ! If the broadband option is not selected, then the input freq (a scalar) 
     ! is stored in the frequency vector
     
-    !     == Routine Arguments ==
-    !     myThid :: Thread number for this instance of the routine.
-    INTEGER, INTENT( IN ) :: myThid
-
+  !     == Routine Arguments ==
+  !     myThid :: Thread number. Unused by IESCO
+  !     msgBuf :: Used to build messages for printing.
+    INTEGER, INTENT( IN )   :: myThid
+    CHARACTER*(MAX_LEN_MBUF):: msgBuf
+  
+  !     == Local Variables ==
     REAL (KIND=_RL90),  INTENT( IN ) :: freq0   ! Source frequency
     CHARACTER,          INTENT( IN ) :: BroadbandOption*( 1 )
     INTEGER :: ifreq
@@ -72,11 +75,15 @@ CONTAINS
     ! Broadband run?
     IF ( BroadbandOption == 'B' ) THEN
 #ifdef IHOP_WRITE_OUT
-        WRITE( PRTFile, * ) '________________________________________________', &
+        WRITE(msgBuf,'(2A)')'________________________________________________',&
                             '__________________________'
-        WRITE( PRTFile, * )
-        WRITE( PRTFile, * )
-        WRITE( PRTFile, * ) 'Number of frequencies =', Nfreq
+        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(A)') NEW_LINE('a')
+        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(A)') NEW_LINE('a')
+        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(A,I)') 'Number of frequencies =', Nfreq
+        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
         IF ( Nfreq <= 0 ) THEN
 #ifdef IHOP_WRITE_OUT
@@ -99,17 +106,20 @@ CONTAINS
 
     IF ( BroadbandOption == 'B' ) THEN
 #ifdef IHOP_WRITE_OUT
-       WRITE( PRTFile, * ) 'Frequencies (Hz)'
+       WRITE(msgBuf,'(A)') 'Frequencies (Hz)'
+       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
        freqVec( 3 ) = -999.9
        !READ(  ENVFile, * ) freqVec( 1 : Nfreq )
        CALL SubTab( freqVec, Nfreq )
 
 #ifdef IHOP_WRITE_OUT
-       WRITE( PRTFile, "( 5G14.6 )" ) ( freqVec( ifreq ), ifreq = 1, &
-                                      MIN( Nfreq, Number_to_Echo ) )
+       WRITE( msgBuf, '(5G14.6)' ) ( freqVec( ifreq ), ifreq = 1, &
+           MIN( Nfreq, Number_to_Echo ) )
+       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
        IF ( Nfreq > Number_to_Echo ) &
-           WRITE( PRTFile,  "( G14.6 )" ) ' ... ', freqVec( Nfreq )
+           WRITE( msgBuf,'(G14.6)' ) ' ... ', freqVec( Nfreq )
+           CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
     ELSE
        freqVec( 1 ) = freq0
@@ -124,9 +134,13 @@ CONTAINS
 
     ! Reads source x-y coordinates
     
-    !     == Routine Arguments ==
-    !     myThid :: Thread number for this instance of the routine.
-    INTEGER, INTENT( IN ) :: myThid
+  !     == Routine Arguments ==
+  !     myThid :: Thread number. Unused by IESCO
+  !     msgBuf :: Used to build messages for printing.
+    INTEGER, INTENT( IN )   :: myThid
+    CHARACTER*(MAX_LEN_MBUF):: msgBuf
+  
+  !     == Local Variables ==
 
 #ifdef IHOP_THREED
     CALL ReadVector( Pos%NSx, Pos%Sx, 'source   x-coordinates, Sx', 'km', &
@@ -156,10 +170,13 @@ CONTAINS
     ! zMin and zMax are limits for those depths; sources and receivers are 
     ! shifted to be within those limits
 
-    !     == Routine Arguments ==
-    !     myThid :: Thread number for this instance of the routine.
-    INTEGER, INTENT( IN ) :: myThid
-
+  !     == Routine Arguments ==
+  !     myThid :: Thread number. Unused by IESCO
+  !     msgBuf :: Used to build messages for printing.
+    INTEGER, INTENT( IN )   :: myThid
+    CHARACTER*(MAX_LEN_MBUF):: msgBuf
+  
+  !     == Local Variables ==
     REAL,    INTENT( IN ) :: zMin, zMax
 
     CALL ReadVector( Pos%NSz, Pos%Sz, 'Source   depths, Sz', 'm', &
@@ -192,26 +209,30 @@ CONTAINS
 #ifdef IHOP_WRITE_OUT
     IF ( ANY( Pos%Sz( 1 : Pos%NSz ) < zMin ) ) THEN
        WHERE ( Pos%Sz < zMin ) Pos%Sz = zMin
-       WRITE( PRTFile, * ) 'Warning in ReadSzRz : Source above or too ',&
+       WRITE(msgBuf,'(2A)') 'Warning in ReadSzRz : Source above or too ',&
                            'near the top bdry has been moved down'
+       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     END IF
 
     IF ( ANY( Pos%Sz( 1 : Pos%NSz ) > zMax ) ) THEN
        WHERE( Pos%Sz > zMax ) Pos%Sz = zMax
-       WRITE( PRTFile, * ) 'Warning in ReadSzRz : Source below or too ',&
+       WRITE(msgBuf,'(2A)') 'Warning in ReadSzRz : Source below or too ',&
                            'near the bottom bdry has been moved up'
+       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     END IF
 
     IF ( ANY( Pos%Rz( 1 : Pos%NRz ) < zMin ) ) THEN
        WHERE( Pos%Rz < zMin ) Pos%Rz = zMin
-       WRITE( PRTFile, * ) 'Warning in ReadSzRz : Receiver above or too ',&
+       WRITE(msgBuf,'(2A)') 'Warning in ReadSzRz : Receiver above or too ',&
            'near the top bdry has been moved down'
+       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     END IF
 
     IF ( ANY( Pos%Rz( 1 : Pos%NRz ) > zMax ) ) THEN
        WHERE( Pos%Rz > zMax ) Pos%Rz = zMax
-       WRITE( PRTFile, * ) 'Warning in ReadSzRz : Receiver below or too ',&
+       WRITE(msgBuf,'(2A)') 'Warning in ReadSzRz : Receiver below or too ',&
                            'near the bottom bdry has been moved up'
+       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     END IF
 #endif /* IHOP_WRITE_OUT */
 
@@ -222,9 +243,13 @@ CONTAINS
 
   SUBROUTINE ReadRcvrRanges( myThid )
 
-    !     == Routine Arguments ==
-    !     myThid :: Thread number for this instance of the routine.
-    INTEGER, INTENT( IN ) :: myThid
+  !     == Routine Arguments ==
+  !     myThid :: Thread number. Unused by IESCO
+  !     msgBuf :: Used to build messages for printing.
+    INTEGER, INTENT( IN )   :: myThid
+    CHARACTER*(MAX_LEN_MBUF):: msgBuf
+  
+  !     == Local Variables ==
 
     ! IESCO22: assuming receiver positions are equally spaced
     CALL ReadVector( Pos%NRr, Pos%Rr, 'Receiver ranges, Rr', 'km', myThid )
@@ -249,9 +274,13 @@ CONTAINS
 #ifdef IHOP_THREED
   SUBROUTINE ReadRcvrBearings( myThid )   ! for 3D bellhop
 
-    !     == Routine Arguments ==
-    !     myThid :: Thread number for this instance of the routine.
-    INTEGER, INTENT( IN ) :: myThid
+  !     == Routine Arguments ==
+  !     myThid :: Thread number. Unused by IESCO
+  !     msgBuf :: Used to build messages for printing.
+    INTEGER, INTENT( IN )   :: myThid
+    CHARACTER*(MAX_LEN_MBUF):: msgBuf
+  
+  !     == Local Variables ==
 
 ! IEsco23: NOT SUPPORTED IN ihop
     CALL ReadVector( Pos%Ntheta, Pos%theta, 'receiver bearings, theta', &
@@ -288,10 +317,13 @@ CONTAINS
     ! Description is something like 'receiver ranges'
     ! Units       is something like 'km'
 
-    !     == Routine Arguments ==
-    !     myThid :: Thread number for this instance of the routine.
-    INTEGER, INTENT( IN ) :: myThid
- 
+  !     == Routine Arguments ==
+  !     myThid :: Thread number. Unused by IESCO
+  !     msgBuf :: Used to build messages for printing.
+    INTEGER, INTENT( IN )   :: myThid
+    CHARACTER*(MAX_LEN_MBUF):: msgBuf
+  
+  !     == Local Variables ==
     INTEGER,                        INTENT( IN ) :: Nx
     REAL (KIND=_RL90), ALLOCATABLE, INTENT( INOUT ) :: x( : )
     CHARACTER,                      INTENT( IN ) :: Description*( * ), &
@@ -299,11 +331,15 @@ CONTAINS
     INTEGER :: ix
    
 #ifdef IHOP_WRITE_OUT
-    WRITE( PRTFile, * )
-    WRITE( PRTFile, * ) '__________________________________________________', &
+    WRITE(msgBuf,'(A)') NEW_LINE('a')
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    WRITE(msgBuf,'(2A)')'__________________________________________________', &
                         '________________________'
-    WRITE( PRTFile, * )
-    WRITE( PRTFile, * ) 'Number of ' // Description // ' = ', Nx
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    WRITE(msgBuf,'(A)') NEW_LINE('a')
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    WRITE(msgBuf,'(A)') 'Number of ' // Description // ' = ', Nx
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
 
     IF ( Nx <= 0 ) THEN
@@ -326,17 +362,23 @@ CONTAINS
     END IF
 
 #ifdef IHOP_WRITE_OUT
-    WRITE( PRTFile, * ) Description // ' (' // Units // ')'
+    WRITE(msgBuf,'(A)') Description // ' (' // Units // ')'
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
 
     CALL SubTab( x, Nx )
     CALL Sort(   x, Nx )
 
 #ifdef IHOP_WRITE_OUT
-    WRITE( PRTFile, "( 5G14.6 )" ) ( x( ix ), ix = 1, MIN( Nx, Number_to_Echo ) )
-    IF ( Nx > Number_to_Echo ) WRITE( PRTFile,  "( G14.6 )" ) ' ... ', x( Nx )
+    WRITE(msgBuf,'(5G14.6)') ( x( ix ), ix = 1, MIN( Nx, Number_to_Echo ) )
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    IF ( Nx > Number_to_Echo ) THEN
+        WRITE(msgBuf,'(G14.6)') ' ... ', x( Nx )
+        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    END IF
 
-    WRITE( PRTFile, * )
+    WRITE(msgBuf,'(A)') NEW_LINE('a')
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
 
     ! Vectors in km should be converted to m for internal use

--- a/ihop/srpos_mod.F90
+++ b/ihop/srpos_mod.F90
@@ -87,8 +87,9 @@ CONTAINS
 #endif /* IHOP_WRITE_OUT */
         IF ( Nfreq <= 0 ) THEN
 #ifdef IHOP_WRITE_OUT
-            WRITE(errorMessageUnit,'(2A)') 'SRPOSITIONS ReadfreqVec: ', &
+            WRITE(msgBuf,'(2A)') 'SRPOSITIONS ReadfreqVec: ', &
                                  'Number of frequencies must be positive'
+            CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
             STOP 'ABNORMAL END: S/R ReadfreqVec'
         END IF
@@ -98,8 +99,9 @@ CONTAINS
     ALLOCATE( freqVec( MAX( 3, Nfreq ) ), Stat = IAllocStat )
     IF ( IAllocStat /= 0 ) THEN
 #ifdef IHOP_WRITE_OUT
-        WRITE(errorMessageUnit,'(2A)') 'SRPOSITIONS ReadfreqVec: ', &
+        WRITE(msgBuf,'(2A)') 'SRPOSITIONS ReadfreqVec: ', &
                              'Number of frequencies too large'
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
         STOP 'ABNORMAL END: S/R ReadfreqVec'
     END IF
@@ -151,7 +153,8 @@ CONTAINS
     ALLOCATE( Pos%Sx( 1 ), Pos%Sy( 1 ), Stat=IAllocStat)
     IF (IAllocStat/=0) THEN
 #ifdef IHOP_WRITE_OUT
-        WRITE(errorMessageUnit, *) 'allocation failed', IAllocStat
+        WRITE(msgBuf, *) 'allocation failed', IAllocStat
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
         STOP 'ABNORMAL END: S/R ReadSxSy'
     END IF
@@ -188,8 +191,9 @@ CONTAINS
     ALLOCATE( Pos%ws( Pos%NSz ), Pos%iSz( Pos%NSz ), Stat = IAllocStat )
     IF ( IAllocStat /= 0 ) THEN
 #ifdef IHOP_WRITE_OUT
-        WRITE(errorMessageUnit,'(2A)') 'SRPOSITIONS ReadSzRz: ', &
+        WRITE(msgBuf,'(2A)') 'SRPOSITIONS ReadSzRz: ', &
                              'Too many sources'
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
         STOP 'ABNORMAL END: S/R ReadSzRz'
     END IF
@@ -198,8 +202,9 @@ CONTAINS
     ALLOCATE( Pos%wr( Pos%NRz ), Pos%iRz( Pos%NRz ), Stat = IAllocStat  )
     IF ( IAllocStat /= 0 ) THEN
 #ifdef IHOP_WRITE_OUT
-        WRITE(errorMessageUnit,'(2A)') 'SRPOSITIONS ReadSzRz: ', &
+        WRITE(msgBuf,'(2A)') 'SRPOSITIONS ReadSzRz: ', &
                              'Too many receivers'
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
         STOP 'ABNORMAL END: S/R ReadSzRz'
     END IF
@@ -260,8 +265,9 @@ CONTAINS
 
     IF ( .NOT. monotonic( Pos%Rr, Pos%NRr ) ) THEN
 #ifdef IHOP_WRITE_OUT
-        WRITE(errorMessageUnit,'(2A)') 'SRPOSITIONS ReadRcvrRanges: ', &
+        WRITE(msgBuf,'(2A)') 'SRPOSITIONS ReadRcvrRanges: ', &
                              'Receiver ranges are not monotonically increasing'
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
         STOP 'ABNORMAL END: S/R ReadRcvrRanges'
     END IF 
@@ -300,8 +306,9 @@ CONTAINS
 
     IF ( .NOT. monotonic( Pos%theta, Pos%Ntheta ) ) THEN
 #ifdef IHOP_WRITE_OUT
-        WRITE(errorMessageUnit,'(2A)') 'SRPOSITIONS ReadRcvrBearings: ', &
+        WRITE(msgBuf,'(2A)') 'SRPOSITIONS ReadRcvrBearings: ', &
                             'Receiver bearings are not monotonically increasing'
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
         STOP 'ABNORMAL END: S/R ReadRcvrBearings'
     END IF 
@@ -344,8 +351,9 @@ CONTAINS
 
     IF ( Nx <= 0 ) THEN
 #ifdef IHOP_WRITE_OUT
-        WRITE(errorMessageUnit,'(2A)') 'SRPOSITIONS ReadVector: ', &
+        WRITE(msgBuf,'(2A)') 'SRPOSITIONS ReadVector: ', &
                              'Number of ' // Description // 'must be positive'
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
         STOP 'ABNORMAL END: S/R ReadVector'
     END IF
@@ -354,8 +362,9 @@ CONTAINS
         ALLOCATE( x( MAX( 3, Nx ) ), Stat = IAllocStat )
         IF ( IAllocStat /= 0 ) THEN
 #ifdef IHOP_WRITE_OUT
-            WRITE(errorMessageUnit,'(2A)') 'SRPOSITIONS ReadVector: ', &
+            WRITE(msgBuf,'(2A)') 'SRPOSITIONS ReadVector: ', &
                                 'Too many ' // Description
+            CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
             STOP 'ABNORMAL END: S/R ReadVector'
         END IF

--- a/ihop/srpos_mod.F90
+++ b/ihop/srpos_mod.F90
@@ -82,7 +82,7 @@ CONTAINS
         CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
         WRITE(msgBuf,'(A)') 
         CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-        WRITE(msgBuf,'(A,I)') 'Number of frequencies =', Nfreq
+        WRITE(msgBuf,'(A,I10)') 'Number of frequencies =', Nfreq
         CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
         IF ( Nfreq <= 0 ) THEN
@@ -345,7 +345,7 @@ CONTAINS
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     WRITE(msgBuf,'(A)') 
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-    WRITE(msgBuf,'(A,I)') 'Number of ' // Description // ' = ', Nx
+    WRITE(msgBuf,'(A,I10)') 'Number of ' // Description // ' = ', Nx
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
 

--- a/ihop/ssp_mod.F90
+++ b/ihop/ssp_mod.F90
@@ -116,11 +116,13 @@ CONTAINS
     !   Task = 'TAB' to tabulate cp, cs, rhoT 
     !   Task = 'INI' to initialize
 
-    ! == Routine Arguments ==
-    ! myThid :: Thread number for this instance of the routine
-    INTEGER, INTENT(IN) :: myThid
-
-    ! == Local Variables ==
+  !     == Routine Arguments ==
+  !     myThid :: Thread number. Unused by IESCO
+  !     msgBuf :: Used to build messages for printing.
+    INTEGER, INTENT( IN )   :: myThid
+    CHARACTER*(MAX_LEN_MBUF):: msgBuf
+  
+  !     == Local Variables ==
     REAL (KIND=_RL90), INTENT( IN  ) :: freq
     REAL (KIND=_RL90), INTENT( IN  ) :: x( 2 )  ! r-z SSP evaluation point
     CHARACTER( LEN=3), INTENT( IN  ) :: Task
@@ -145,7 +147,8 @@ CONTAINS
        CALL Analytic( x, c, cimag, gradc, crr, crz, czz, rho, Task, myThid )
     CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
-       WRITE( PRTFile, * ) 'Profile option: ', SSP%Type
+       WRITE(msgBuf,'(2A)') 'Profile option: ', SSP%Type
+       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
        WRITE(errorMessageUnit,'(2A)') 'SSPMOD EvaluateSSP: ', 'Invalid SSP profile option'
 #endif /* IHOP_WRITE_OUT */
        STOP 'ABNORMAL END: S/R EvaluateSSP'
@@ -160,11 +163,11 @@ CONTAINS
 
     ! N2-linear interpolation of SSP data
 
-    ! == Routine Arguments ==
-    ! myThid :: Thread number for this instance of the routine
-    INTEGER, INTENT(IN) :: myThid
-
-    ! == Local Variables ==
+  !     == Routine Arguments ==
+  !     myThid :: Thread number. Unused by IESCO
+    INTEGER, INTENT( IN )   :: myThid
+  
+  !     == Local Variables ==
     REAL (KIND=_RL90), INTENT( IN  ) :: freq
     REAL (KIND=_RL90), INTENT( IN  ) :: x( 2 )  ! r-z SSP evaluation point
     CHARACTER (LEN=3), INTENT( IN  ) :: Task
@@ -222,11 +225,11 @@ CONTAINS
 
     ! c-linear interpolation of SSP data
 
-    ! == Routine Arguments ==
-    ! myThid :: Thread number for this instance of the routine
-    INTEGER, INTENT(IN) :: myThid
-
-    ! == Local Variables ==
+  !     == Routine Arguments ==
+  !     myThid :: Thread number. Unused by IESCO
+    INTEGER, INTENT( IN )   :: myThid
+  
+  !     == Local Variables ==
     REAL (KIND=_RL90), INTENT( IN  ) :: freq
     REAL (KIND=_RL90), INTENT( IN  ) :: x( 2 )  ! r-z SSP evaluation point
     CHARACTER (LEN=3), INTENT( IN  ) :: Task
@@ -273,11 +276,11 @@ CONTAINS
 
     USE pchip_mod,  only: PCHIP
 
-    ! == Routine Arguments ==
-    ! myThid :: Thread number for this instance of the routine
-    INTEGER, INTENT(IN) :: myThid
-
-    ! == Local Variables ==
+  !     == Routine Arguments ==
+  !     myThid :: Thread number. Unused by IESCO
+    INTEGER, INTENT( IN )   :: myThid
+  
+  !     == Local Variables ==
     REAL (KIND=_RL90), INTENT( IN  ) :: freq
     REAL (KIND=_RL90), INTENT( IN  ) :: x( 2 )  ! r-z SSP evaluation point
     CHARACTER (LEN=3), INTENT( IN  ) :: Task
@@ -346,11 +349,11 @@ CONTAINS
 
     ! Cubic spline interpolation
 
-    ! == Routine Arguments ==
-    ! myThid :: Thread number for this instance of the routine
-    INTEGER, INTENT(IN) :: myThid
-
-    ! == Local Variables ==
+  !     == Routine Arguments ==
+  !     myThid :: Thread number. Unused by IESCO
+    INTEGER, INTENT( IN )   :: myThid
+  
+  !     == Local Variables ==
     REAL (KIND=_RL90), INTENT( IN )  :: freq
     REAL (KIND=_RL90), INTENT( IN  ) :: x( 2 )  ! r-z SSP evaluation point
     CHARACTER (LEN=3), INTENT( IN  ) :: Task
@@ -419,13 +422,15 @@ CONTAINS
 
   SUBROUTINE Quad( x, c, cimag, gradc, crr, crz, czz, rho, freq, Task, myThid )
 
-    ! Bilinear quadrilatteral interpolation of SSP data in 2D, SSP%Type = 'Q'
+  ! Bilinear quadrilatteral interpolation of SSP data in 2D, SSP%Type = 'Q'
 
-    ! == Routine Arguments ==
-    ! myThid :: Thread number for this instance of the routine
-    INTEGER, INTENT(IN) :: myThid
-
-    ! == Local Variables ==
+  !     == Routine Arguments ==
+  !     myThid :: Thread number. Unused by IESCO
+  !     msgBuf :: Used to build messages for printing.
+    INTEGER, INTENT( IN )   :: myThid
+    CHARACTER*(MAX_LEN_MBUF):: msgBuf
+  
+  !     == Local Variables ==
     REAL (KIND=_RL90), INTENT( IN  ) :: freq
     REAL (KIND=_RL90), INTENT( IN  ) :: x( 2 )  ! r-z SSP evaluation point
     CHARACTER (LEN=3), INTENT( IN  ) :: Task
@@ -473,9 +478,11 @@ CONTAINS
        ! Check that x is inside the box where the sound speed is defined
        IF ( x( 1 ) < SSP%Seg%r( 1 ) .OR. x( 1 ) > SSP%Seg%r( SSP%Nr ) ) THEN
 #ifdef IHOP_WRITE_OUT
-          WRITE( PRTFile, * ) 'ray is outside the box where ocean ',&
+          WRITE(msgBuf,'(2A)') 'ray is outside the box where ocean ',&
                               'soundspeed is defined'
-          WRITE( PRTFile, * ) ' x = ( r, z ) = ', x
+          CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+          WRITE(msgBuf,'(A,2F10.4)') ' x = ( r, z ) = ', x
+          CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
           WRITE(errorMessageUnit,'(2A)') 'SSPMOD Quad: ', &
                     'ray is outside the box where the soundspeed is defined'
 #endif /* IHOP_WRITE_OUT */
@@ -545,11 +552,13 @@ CONTAINS
 
   SUBROUTINE Analytic( x, c, cimag, gradc, crr, crz, czz, rho, Task, myThid )
 
-    ! == Routine Arguments ==
-    ! myThid :: Thread number for this instance of the routine
-    INTEGER, INTENT(IN) :: myThid
-
-    ! == Local Variables ==
+  !     == Routine Arguments ==
+  !     myThid :: Thread number. Unused by IESCO
+  !     msgBuf :: Used to build messages for printing.
+    INTEGER, INTENT( IN )   :: myThid
+    CHARACTER*(MAX_LEN_MBUF):: msgBuf
+  
+  !     == Local Variables ==
     REAL (KIND=_RL90), INTENT( IN  ) :: x( 2 )
     CHARACTER (LEN=3), INTENT( IN  ) :: Task
     REAL (KIND=_RL90), INTENT( OUT ) :: c, cimag, gradc( 2 ), crr, crz, czz, rho
@@ -557,7 +566,8 @@ CONTAINS
 
     IF ( Task == 'INI' ) THEN
 #ifdef IHOP_WRITE_OUT
-       WRITE( PRTFile, * ) 'Analytic SSP option'
+       WRITE(msgBuf,'(A)') 'Analytic SSP option'
+       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
        SSP%NPts = 2
        SSP%z(1) = 0.0
@@ -601,10 +611,13 @@ CONTAINS
 
     USE atten_mod, only: CRCI
 
-    ! == Routine Arguments ==
-    ! myThid :: Thread number for this instance of the routine
-    INTEGER, INTENT(IN) :: myThid
-
+  !     == Routine Arguments ==
+  !     myThid :: Thread number. Unused by IESCO
+  !     msgBuf :: Used to build messages for printing.
+    INTEGER, INTENT( IN )   :: myThid
+    CHARACTER*(MAX_LEN_MBUF):: msgBuf
+  
+  !     == Local Variables ==
     REAL (KIND=_RL90), INTENT(IN) :: Depth, freq
     INTEGER :: iz2
 
@@ -615,27 +628,39 @@ CONTAINS
         FORM = 'FORMATTED', STATUS = 'OLD', IOSTAT = iostat )
     IF ( IOSTAT /= 0 ) THEN   ! successful open?
 #ifdef IHOP_WRITE_OUT
-       WRITE( PRTFile, * ) 'SSPFile = ', TRIM( IHOP_fileroot ) // '.ssp'
-       WRITE(errorMessageUnit,'(2A)') 'SSPMOD ReadSSP: ', 'Unable to open the SSP file'
+       WRITE(msgBuf,'(A)') 'SSPFile = ', TRIM( IHOP_fileroot ) // '.ssp'
+       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+       WRITE(errorMessageUnit,'(A)') 'SSPMOD ReadSSP: Unable to open the SSP file'
 #endif /* IHOP_WRITE_OUT */
        STOP 'ABNORMAL END: S/R ReadSSP'
     END IF
 
     ! Write relevant diagnostics
 #ifdef IHOP_WRITE_OUT
-    WRITE( PRTFile, * ) "Sound Speed Field" 
-    WRITE( PRTFile, * ) '____________________________________________________',&
+    WRITE(msgBuf,'(A)') "Sound Speed Field" 
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    WRITE(msgBuf,'(2A)')'____________________________________________________',&
                         '______________________'
-    WRITE( PRTFile, * ) 
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    WRITE(msgBuf,'(A)') NEW_LINE('a')
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
 
     READ( SSPFile,  * ) SSP%Nr, SSP%Nz
 #ifdef IHOP_WRITE_OUT
-    IF (SSP%Nr .GT. 1) WRITE( PRTFile, * ) 'Using range-dependent sound speed'
-    IF (SSP%Nr .EQ. 1) WRITE( PRTFile, * ) 'Using range-independent sound speed'
+    IF (SSP%Nr .GT. 1) THEN
+        WRITE(msgBuf,'(A)') 'Using range-dependent sound speed'
+        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    END IF
+    IF (SSP%Nr .EQ. 1) THEN
+        WRITE(msgBuf,'(A)') 'Using range-independent sound speed'
+        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    END IF
 
-    WRITE( PRTFile, * ) 'Number of SSP ranges = ', SSP%Nr
-    WRITE( PRTFile, * ) 'Number of SSP depths = ', SSP%Nz
+    WRITE(msgBuf,'(A,I)') 'Number of SSP ranges = ', SSP%Nr
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    WRITE(msgBuf,'(A,I)') 'Number of SSP depths = ', SSP%Nz
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
 
     ALLOCATE( SSP%cMat( SSP%Nz, SSP%Nr ), &
@@ -652,18 +677,24 @@ CONTAINS
 
     READ( SSPFile,  * ) SSP%Seg%r( 1 : SSP%Nr )
 #ifdef IHOP_WRITE_OUT
-    WRITE( PRTFile, * )
-    WRITE( PRTFile, * ) 'Profile ranges (km):'
-    WRITE( PRTFile, FMT="( F10.2 )"  ) SSP%Seg%r( 1 : SSP%Nr )
+    WRITE(msgBuf,'(A)') NEW_LINE('a')
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    WRITE(msgBuf,'(A)') 'Profile ranges (km):'
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    WRITE(msgBuf,'(F10.2)') SSP%Seg%r( 1 : SSP%Nr )
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
     SSP%Seg%r = 1000.0 * SSP%Seg%r   ! convert km to m
 
     READ( SSPFile,  * ) SSP%z( 1 : SSP%Nz )
 !#ifdef IHOP_DEBUG
 #ifdef IHOP_WRITE_OUT
-    WRITE( PRTFile, * )
-    WRITE( PRTFile, * ) 'Profile depths (m):'
-    WRITE( PRTFile, FMT="( F10.2 )"  ) SSP%z( 1 : SSP%Nz )
+    WRITE(msgBuf,'(A)') NEW_LINE('a')
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    WRITE(msgBuf,'(A)') 'Profile depths (m):'
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    WRITE(msgBuf,'(F10.2)') SSP%z( 1 : SSP%Nz )
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
 !#endif
 
@@ -671,37 +702,48 @@ CONTAINS
     ! IEsco23: change to allocatable memory since we should know Nz
 #ifdef IHOP_DEBUG
 #ifdef IHOP_WRITE_OUT
-    WRITE( PRTFile, * )
-    WRITE( PRTFile, * ) 'Sound speed matrix:'
-    WRITE( PRTFile, * ) ' Depth (m )     Soundspeed (m/s)'
+    WRITE(msgBuf,'(A)') NEW_LINE('a')
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    WRITE(msgBuf,'(A)') 'Sound speed matrix:'
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    WRITE(msgBuf,'(A)') ' Depth (m )     Soundspeed (m/s)'
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
 #endif /* IHOP_DEBUG */
     DO iz2 = 1, SSP%Nz
        READ(  SSPFile, * ) SSP%cMat( iz2, : )
 #ifdef IHOP_DEBUG
 #ifdef IHOP_WRITE_OUT
-       WRITE( PRTFile, FMT="( 12F10.2 )"  ) SSP%z( iz2 ), SSP%cMat( iz2, : )
+       WRITE(msgBuf,'(12F10.2)') SSP%z( iz2 ), SSP%cMat( iz2, : )
+       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
 #endif /* IHOP_DEBUG */
     END DO
     CLOSE( SSPFile )
 
 #ifdef IHOP_WRITE_OUT
-    WRITE( PRTFile, * )
-    WRITE( PRTFile, * ) 'Sound speed profile:'
-    WRITE( PRTFile, "( '      z         alphaR      betaR     rho        alphaI     betaI'    )" )
-    WRITE( PRTFile, "( '     (m)         (m/s)      (m/s)   (g/cm^3)      (m/s)     (m/s)', / )" )
+    WRITE(msgBuf,'(A)') NEW_LINE('a')
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    WRITE(msgBuf,'(A)') 'Sound speed profile:'
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    WRITE(msgBuf,'(A)')'      z         alphaR      betaR     rho        alphaI     betaI'
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    WRITE(msgBuf,'(A)')'     (m)         (m/s)      (m/s)   (g/cm^3)      (m/s)     (m/s)'
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     
-    WRITE( PRTFile, * ) '____________________________________________________',&
+    WRITE(msgBuf,'(2A)')'____________________________________________________',&
                         '______________________'
-    WRITE( PRTFile, * )
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+    WRITE(msgBuf,'(A)') NEW_LINE('a')
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
     SSP%NPts = 1
     DO iz = 1, MaxSSP 
        alphaR = SSP%cMat( iz, 1 )
 #ifdef IHOP_WRITE_OUT
-       WRITE( PRTFile, FMT="( F10.2, 3X, 2F10.2, 3X, F6.2, 3X, 2F10.4 )" ) &
+       WRITE(msgBuf,'( F10.2, 3X, 2F10.2, 3X, F6.2, 3X, 2F10.4)') &
            SSP%z( iz ), alphaR, betaR, rhoR, alphaI, betaI
+       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
 
        SSP%c(   iz ) = CRCI( SSP%z( iz ), alphaR, alphaI, freq, freq, &
@@ -712,7 +754,8 @@ CONTAINS
        IF ( iz > 1 ) THEN
           IF ( SSP%z( iz ) .LE. SSP%z( iz - 1 ) ) THEN
 #ifdef IHOP_WRITE_OUT
-              WRITE( PRTFile, * ) 'Bad depth in SSP: ', SSP%z( iz )
+              WRITE(msgBuf,'(A,F10.2)') 'Bad depth in SSP: ', SSP%z( iz )
+              CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
               WRITE(errorMessageUnit,'(2A)') 'SSPMOD ReadSSP: ', &
                             'The depths in the SSP must be monotone increasing'
 #endif /* IHOP_WRITE_OUT */
@@ -728,7 +771,8 @@ CONTAINS
        IF ( ABS( SSP%z( iz ) - Depth ) < 100. * EPSILON( 1.0e0 ) ) THEN
           IF ( SSP%NPts == 1 ) THEN
 #ifdef IHOP_WRITE_OUT
-              WRITE( PRTFile, * ) '#SSP points: ', SSP%NPts
+              WRITE(msgBuf,'(A,I)') '#SSP points: ', SSP%NPts
+              CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
               WRITE(errorMessageUnit,'(2A)')  'SSPMOD ReadSSP: ', &
                                     'The SSP must have at least 2 points'
 #endif /* IHOP_WRITE_OUT */
@@ -743,7 +787,8 @@ CONTAINS
  
     ! Fall through means too many points in the profile
 #ifdef IHOP_WRITE_OUT
-    WRITE( PRTFile, * ) 'Max. #SSP points: ', MaxSSP
+    WRITE(msgBuf,'(A,I)') 'Max. #SSP points: ', MaxSSP
+    CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     WRITE(errorMessageUnit,'(2A)') 'SSPMOD ReadSSP: ', &
                          'Number of SSP points exceeds limit'
 #endif /* IHOP_WRITE_OUT */
@@ -751,7 +796,6 @@ CONTAINS
 
     ! I/O on main thread only
     _END_MASTER(myThid)
-    _BARRIER
   RETURN
   END !SUBROUTINE ReadSSP
 
@@ -762,15 +806,17 @@ CONTAINS
 
       use atten_mod, only: CRCI
 
-      ! == Routine Arguments ==
-      ! myThid :: Thread number for this instance of the routine
-      INTEGER, INTENT(IN) :: myThid
-
-      REAL (KIND=_RL90), INTENT(IN) :: Depth, freq
-      REAL (KIND=_RL90) sumweights(IHOP_NPTS_RANGE) 
-
-      ! == Local Variables ==
+  !     == Routine Arguments ==
+  !     myThid :: Thread number. Unused by IESCO
+  !     msgBuf :: Used to build messages for printing.
+    INTEGER, INTENT( IN )   :: myThid
+    CHARACTER*(MAX_LEN_MBUF):: msgBuf
+    CHARACTER*(80)::fmtstr
+  
+  !     == Local Variables ==
       INTEGER ii, jj
+      REAL (KIND=_RL90), INTENT(IN) :: Depth, freq
+      REAL (KIND=_RL90)             :: sumweights(IHOP_NPTS_RANGE)
 
       SSP%Nz = Nr+2 ! add z=0 z=Depth layers 
       SSP%Nr = IHOP_NPTS_RANGE
@@ -810,10 +856,10 @@ CONTAINS
       ! from ocean grid to acoustic grid with IDW
       DO bj=myByLo(myThid),myByHi(myThid)
        DO bi=myBxLo(myThid),myBxHi(myThid)
-        DO j=1-OLy,sNy+OLy
-         DO i=1-OLx,sNx+OLx
-            DO ii=1,IHOP_npts_range
-             DO jj=1,IHOP_npts_idw
+        DO j=1,sNy
+         DO i=1,sNx
+            DO ii=1,IHOP_npts_range !6
+             DO jj=1,IHOP_npts_idw  !4
               ! IDW Interpolate SSP at second order
               IF (xC(i,j,bi,bj) .eq. ihop_xc(ii,jj) .and. &
                   yC(i,j,bi,bj) .eq. ihop_yc(ii,jj)) THEN
@@ -845,7 +891,6 @@ CONTAINS
       !==================================================
 
     ! I/O on main thread only
-    _BARRIER
     _BEGIN_MASTER(myThid)
       ! set vector structured c, rho, and cz for first range point
       DO iz = 1,SSP%Nz
@@ -858,7 +903,8 @@ CONTAINS
         IF ( iz > 1 ) THEN
             IF ( SSP%z( iz ) .LE. SSP%z( iz-1 ) ) THEN
 #ifdef IHOP_WRITE_OUT
-                WRITE( PRTFile, * ) 'Bad depth in SSP: ', SSP%z(iz)
+                WRITE(msgBuf,'(A)') 'Bad depth in SSP: ', SSP%z(iz)
+                CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
                 WRITE( errorMessageUnit,'(2A)' ) 'SSPMOD ExtractSSP: ', &
                             'The depths in the SSP must be monotone increasing'
 #endif /* IHOP_WRITE_OUT */
@@ -873,26 +919,46 @@ CONTAINS
 
       ! Write relevant diagnostics
 #ifdef IHOP_WRITE_OUT
-      WRITE( PRTFile, * ) '________________________________________________', &
+      WRITE(msgBuf,'(2A)') '________________________________________________', &
           '__________________________'
-      WRITE( PRTFile, * )
-      WRITE( PRTFile, * ) "Sound Speed Field" 
-      WRITE( PRTFile, * ) 
+      CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+      WRITE(msgBuf,'(A)') NEW_LINE('a')
+      CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+      WRITE(msgBuf,'(A)') "Sound Speed Field" 
+      CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+      WRITE(msgBuf,'(A)') NEW_LINE('a')
+      CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
   
-      IF (SSP%Nr.GT.1) WRITE( PRTFile, * ) 'Using range-dependent sound speed'
-      IF (SSP%Nr.EQ.1) WRITE( PRTFile, * ) 'Using range-independent sound speed'
+      IF (SSP%Nr.GT.1) THEN
+          WRITE(msgBuf,'(A)') 'Using range-dependent sound speed'
+          CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+      END IF
+      IF (SSP%Nr.EQ.1) THEN
+          WRITE(msgBuf,'(A)') 'Using range-independent sound speed'
+          CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+      END IF
   
-      WRITE( PRTFile, * ) 'Number of SSP ranges = ', SSP%Nr
-      WRITE( PRTFile, * ) 'Number of SSP depths = ', SSP%Nz
+      WRITE(msgBuf,'(A,I)') 'Number of SSP ranges = ', SSP%Nr
+      CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+      WRITE(msgBuf,'(A,I)') 'Number of SSP depths = ', SSP%Nz
+      CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
   
-      WRITE( PRTFile, * )
-      WRITE( PRTFile, * ) 'Profile ranges (km):'
-      WRITE( PRTFile, FMT="( F10.2 )"  ) SSP%Seg%r( 1:SSP%Nr )
-      WRITE( PRTFile, * )
-      WRITE( PRTFile, * ) 'Sound speed matrix:'
-      WRITE( PRTFile, * ) ' Depth (m)     Soundspeed (m/s)'
+      WRITE(msgBuf,'(A)') NEW_LINE('a')
+      CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+      WRITE(msgBuf,'(A)') 'Profile ranges (km):'
+      CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+      WRITE(fmtStr,'(A,I,A)') '(T11,',SSP%Nr, 'F10.2)'
+      WRITE(msgBuf,fmtStr) SSP%Seg%r( 1:SSP%Nr )
+      CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+      WRITE(msgBuf,'(A)') NEW_LINE('a')
+      CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+      WRITE(msgBuf,'(A)') 'Sound speed matrix:'
+      CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+      WRITE(msgBuf,'(A)') ' Depth (m)     Soundspeed (m/s)'
+      CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
       DO iz = 1, SSP%Nz
-         WRITE( PRTFile, FMT="( 12F10.2 )"  ) SSP%z( iz ), SSP%cMat( iz, : )
+         WRITE(msgBuf,'(12F10.2)'  ) SSP%z( iz ), SSP%cMat( iz, : )
+         CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
       END DO
 #endif /* IHOP_WRITE_OUT */
 
@@ -900,7 +966,6 @@ CONTAINS
 
     ! I/O on main thread only
     _END_MASTER(myThid)
-    _BARRIER
   RETURN
   END !SUBROUTINE ExtractSSP
 

--- a/ihop/ssp_mod.F90
+++ b/ihop/ssp_mod.F90
@@ -147,11 +147,12 @@ CONTAINS
        CALL Analytic( x, c, cimag, gradc, crr, crz, czz, rho, Task, myThid )
     CASE DEFAULT
 #ifdef IHOP_WRITE_OUT
-       WRITE(msgBuf,'(2A)') 'Profile option: ', SSP%Type
-       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-       WRITE(errorMessageUnit,'(2A)') 'SSPMOD EvaluateSSP: ', 'Invalid SSP profile option'
+        WRITE(msgBuf,'(2A)') 'Profile option: ', SSP%Type
+        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(2A)') 'SSPMOD EvaluateSSP: ', 'Invalid SSP profile option'
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
-       STOP 'ABNORMAL END: S/R EvaluateSSP'
+        STOP 'ABNORMAL END: S/R EvaluateSSP'
     END SELECT
 
   RETURN
@@ -478,15 +479,16 @@ CONTAINS
        ! Check that x is inside the box where the sound speed is defined
        IF ( x( 1 ) < SSP%Seg%r( 1 ) .OR. x( 1 ) > SSP%Seg%r( SSP%Nr ) ) THEN
 #ifdef IHOP_WRITE_OUT
-          WRITE(msgBuf,'(2A)') 'ray is outside the box where ocean ',&
+            WRITE(msgBuf,'(2A)') 'ray is outside the box where ocean ',&
                               'soundspeed is defined'
-          CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-          WRITE(msgBuf,'(A,2F10.4)') ' x = ( r, z ) = ', x
-          CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-          WRITE(errorMessageUnit,'(2A)') 'SSPMOD Quad: ', &
+            CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+            WRITE(msgBuf,'(A,2F10.4)') ' x = ( r, z ) = ', x
+            CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+            WRITE(msgBuf,'(2A)') 'SSPMOD Quad: ', &
                     'ray is outside the box where the soundspeed is defined'
+            CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
-          STOP 'ABNORMAL END: S/R Quad'
+            STOP 'ABNORMAL END: S/R Quad'
        END IF
 
        ! find range-segment where x(1) in [ SSP%Seg%r( iSegr ), SSP%Seg%r( iSegr+1 ) )
@@ -508,9 +510,11 @@ CONTAINS
        delta_z = SSP%z( iSegz+1 ) - SSP%z( iSegz )
        IF (delta_z <= 0 .OR. s2 > delta_z) THEN
 #ifdef IHOP_WRITE_OUT
-          WRITE(errorMessageUnit, *) delta_z, s2, iSegz, SSP%z(iSegz)
-          WRITE(errorMessageUnit,'(2A)') 'SSPMOD Quad: ', &
+            WRITE(msgBuf, *) delta_z, s2, iSegz, SSP%z(iSegz)
+            CALL PRINT_ERROR( msgBuf,myThid )
+            WRITE(msgBuf,'(2A)') 'SSPMOD Quad: ', &
                             'depth is not monotonically increasing in SSP%z'
+            CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
           STOP 'ABNORMAL END: S/R Quad'
        END IF
@@ -628,11 +632,12 @@ CONTAINS
         FORM = 'FORMATTED', STATUS = 'OLD', IOSTAT = iostat )
     IF ( IOSTAT /= 0 ) THEN   ! successful open?
 #ifdef IHOP_WRITE_OUT
-       WRITE(msgBuf,'(A)') 'SSPFile = ', TRIM( IHOP_fileroot ) // '.ssp'
-       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-       WRITE(errorMessageUnit,'(A)') 'SSPMOD ReadSSP: Unable to open the SSP file'
+        WRITE(msgBuf,'(A)') 'SSPFile = ', TRIM( IHOP_fileroot ) // '.ssp'
+        CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(A)') 'SSPMOD ReadSSP: Unable to open the SSP file'
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
-       STOP 'ABNORMAL END: S/R ReadSSP'
+        STOP 'ABNORMAL END: S/R ReadSSP'
     END IF
 
     ! Write relevant diagnostics
@@ -669,10 +674,11 @@ CONTAINS
               STAT = iallocstat )
     IF ( iallocstat /= 0 ) THEN
 #ifdef IHOP_WRITE_OUT
-       WRITE(errorMessageUnit,'(2A)') 'SSPMOD ReadSSP: ', &
+        WRITE(msgBuf,'(2A)') 'SSPMOD ReadSSP: ', &
                             'Insufficient memory to store SSP'
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
-       STOP 'ABNORMAL END: S/R ReadSSP'
+        STOP 'ABNORMAL END: S/R ReadSSP'
     END IF
 
     READ( SSPFile,  * ) SSP%Seg%r( 1 : SSP%Nr )
@@ -754,12 +760,13 @@ CONTAINS
        IF ( iz > 1 ) THEN
           IF ( SSP%z( iz ) .LE. SSP%z( iz - 1 ) ) THEN
 #ifdef IHOP_WRITE_OUT
-              WRITE(msgBuf,'(A,F10.2)') 'Bad depth in SSP: ', SSP%z( iz )
-              CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-              WRITE(errorMessageUnit,'(2A)') 'SSPMOD ReadSSP: ', &
+                WRITE(msgBuf,'(A,F10.2)') 'Bad depth in SSP: ', SSP%z( iz )
+                CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+                WRITE(msgBuf,'(2A)') 'SSPMOD ReadSSP: ', &
                             'The depths in the SSP must be monotone increasing'
+                CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
-              STOP 'ABNORMAL END: S/R ReadSSP'
+                STOP 'ABNORMAL END: S/R ReadSSP'
           END IF
        END IF
 
@@ -771,12 +778,13 @@ CONTAINS
        IF ( ABS( SSP%z( iz ) - Depth ) < 100. * EPSILON( 1.0e0 ) ) THEN
           IF ( SSP%NPts == 1 ) THEN
 #ifdef IHOP_WRITE_OUT
-              WRITE(msgBuf,'(A,I)') '#SSP points: ', SSP%NPts
-              CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-              WRITE(errorMessageUnit,'(2A)')  'SSPMOD ReadSSP: ', &
+                WRITE(msgBuf,'(A,I)') '#SSP points: ', SSP%NPts
+                CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
+                WRITE(msgBuf,'(2A)')  'SSPMOD ReadSSP: ', &
                                     'The SSP must have at least 2 points'
+                CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
-              STOP 'ABNORMAL END: S/R ReadSSP'
+                STOP 'ABNORMAL END: S/R ReadSSP'
           END IF
 
           RETURN
@@ -789,8 +797,9 @@ CONTAINS
 #ifdef IHOP_WRITE_OUT
     WRITE(msgBuf,'(A,I)') 'Max. #SSP points: ', MaxSSP
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-    WRITE(errorMessageUnit,'(2A)') 'SSPMOD ReadSSP: ', &
+    WRITE(msgBuf,'(2A)') 'SSPMOD ReadSSP: ', &
                          'Number of SSP points exceeds limit'
+    CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
     STOP 'ABNORMAL END: S/R ReadSSP'
 
@@ -827,8 +836,9 @@ CONTAINS
                 STAT = iallocstat )
       IF ( iallocstat /= 0 ) THEN
 #ifdef IHOP_WRITE_OUT
-        WRITE(errorMessageUnit,'(2A)') 'SSPMOD ExtractSSP: ', &
+        WRITE(msgBuf,'(2A)') 'SSPMOD ExtractSSP: ', &
                              'Insufficient memory to store SSP'
+        CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
         STOP 'ABNORMAL END: S/R ExtractSSP'
       END IF
@@ -905,8 +915,9 @@ CONTAINS
 #ifdef IHOP_WRITE_OUT
                 WRITE(msgBuf,'(A)') 'Bad depth in SSP: ', SSP%z(iz)
                 CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-                WRITE( errorMessageUnit,'(2A)' ) 'SSPMOD ExtractSSP: ', &
+                WRITE( msgBuf,'(2A)' ) 'SSPMOD ExtractSSP: ', &
                             'The depths in the SSP must be monotone increasing'
+                CALL PRINT_ERROR( msgBuf,myThid )
 #endif /* IHOP_WRITE_OUT */
                 STOP 'ABNORMAL END: S/R ExtractSSP'
             END IF

--- a/ihop/ssp_mod.F90
+++ b/ihop/ssp_mod.F90
@@ -640,9 +640,9 @@ CONTAINS
     WRITE(msgBuf,'(A)') "Sound Speed Field" 
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     WRITE(msgBuf,'(2A)')'____________________________________________________',&
-                        '______________________'
+                        '_______'
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-    WRITE(msgBuf,'(A)') NEW_LINE('a')
+    WRITE(msgBuf,'(A)') 
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
 
@@ -677,7 +677,7 @@ CONTAINS
 
     READ( SSPFile,  * ) SSP%Seg%r( 1 : SSP%Nr )
 #ifdef IHOP_WRITE_OUT
-    WRITE(msgBuf,'(A)') NEW_LINE('a')
+    WRITE(msgBuf,'(A)') 
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     WRITE(msgBuf,'(A)') 'Profile ranges (km):'
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
@@ -689,7 +689,7 @@ CONTAINS
     READ( SSPFile,  * ) SSP%z( 1 : SSP%Nz )
 !#ifdef IHOP_DEBUG
 #ifdef IHOP_WRITE_OUT
-    WRITE(msgBuf,'(A)') NEW_LINE('a')
+    WRITE(msgBuf,'(A)') 
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     WRITE(msgBuf,'(A)') 'Profile depths (m):'
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
@@ -702,7 +702,7 @@ CONTAINS
     ! IEsco23: change to allocatable memory since we should know Nz
 #ifdef IHOP_DEBUG
 #ifdef IHOP_WRITE_OUT
-    WRITE(msgBuf,'(A)') NEW_LINE('a')
+    WRITE(msgBuf,'(A)') 
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     WRITE(msgBuf,'(A)') 'Sound speed matrix:'
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
@@ -722,7 +722,7 @@ CONTAINS
     CLOSE( SSPFile )
 
 #ifdef IHOP_WRITE_OUT
-    WRITE(msgBuf,'(A)') NEW_LINE('a')
+    WRITE(msgBuf,'(A)') 
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     WRITE(msgBuf,'(A)') 'Sound speed profile:'
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
@@ -732,9 +732,9 @@ CONTAINS
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     
     WRITE(msgBuf,'(2A)')'____________________________________________________',&
-                        '______________________'
+                        '_______'
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-    WRITE(msgBuf,'(A)') NEW_LINE('a')
+    WRITE(msgBuf,'(A)') 
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
     SSP%NPts = 1
@@ -919,14 +919,14 @@ CONTAINS
 
       ! Write relevant diagnostics
 #ifdef IHOP_WRITE_OUT
-      WRITE(msgBuf,'(2A)') '________________________________________________', &
-          '__________________________'
+      WRITE(msgBuf,'(2A)')'________________________________________________', &
+                          '___________'
       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-      WRITE(msgBuf,'(A)') NEW_LINE('a')
+      WRITE(msgBuf,'(A)') 
       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
       WRITE(msgBuf,'(A)') "Sound Speed Field" 
       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-      WRITE(msgBuf,'(A)') NEW_LINE('a')
+      WRITE(msgBuf,'(A)') 
       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
   
       IF (SSP%Nr.GT.1) THEN
@@ -943,14 +943,14 @@ CONTAINS
       WRITE(msgBuf,'(A,I)') 'Number of SSP depths = ', SSP%Nz
       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
   
-      WRITE(msgBuf,'(A)') NEW_LINE('a')
+      WRITE(msgBuf,'(A)') 
       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
       WRITE(msgBuf,'(A)') 'Profile ranges (km):'
       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
       WRITE(fmtStr,'(A,I,A)') '(T11,',SSP%Nr, 'F10.2)'
       WRITE(msgBuf,fmtStr) SSP%Seg%r( 1:SSP%Nr )
       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-      WRITE(msgBuf,'(A)') NEW_LINE('a')
+      WRITE(msgBuf,'(A)') 
       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
       WRITE(msgBuf,'(A)') 'Sound speed matrix:'
       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )

--- a/ihop/ssp_mod.F90
+++ b/ihop/ssp_mod.F90
@@ -662,9 +662,9 @@ CONTAINS
         CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     END IF
 
-    WRITE(msgBuf,'(A,I)') 'Number of SSP ranges = ', SSP%Nr
+    WRITE(msgBuf,'(A,I10)') 'Number of SSP ranges = ', SSP%Nr
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-    WRITE(msgBuf,'(A,I)') 'Number of SSP depths = ', SSP%Nz
+    WRITE(msgBuf,'(A,I10)') 'Number of SSP depths = ', SSP%Nz
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
 #endif /* IHOP_WRITE_OUT */
 
@@ -778,7 +778,7 @@ CONTAINS
        IF ( ABS( SSP%z( iz ) - Depth ) < 100. * EPSILON( 1.0e0 ) ) THEN
           IF ( SSP%NPts == 1 ) THEN
 #ifdef IHOP_WRITE_OUT
-                WRITE(msgBuf,'(A,I)') '#SSP points: ', SSP%NPts
+                WRITE(msgBuf,'(A,I10)') '#SSP points: ', SSP%NPts
                 CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
                 WRITE(msgBuf,'(2A)')  'SSPMOD ReadSSP: ', &
                                     'The SSP must have at least 2 points'
@@ -795,7 +795,7 @@ CONTAINS
  
     ! Fall through means too many points in the profile
 #ifdef IHOP_WRITE_OUT
-    WRITE(msgBuf,'(A,I)') 'Max. #SSP points: ', MaxSSP
+    WRITE(msgBuf,'(A,I10)') 'Max. #SSP points: ', MaxSSP
     CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
     WRITE(msgBuf,'(2A)') 'SSPMOD ReadSSP: ', &
                          'Number of SSP points exceeds limit'
@@ -949,16 +949,16 @@ CONTAINS
           CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
       END IF
   
-      WRITE(msgBuf,'(A,I)') 'Number of SSP ranges = ', SSP%Nr
+      WRITE(msgBuf,'(A,I10)') 'Number of SSP ranges = ', SSP%Nr
       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-      WRITE(msgBuf,'(A,I)') 'Number of SSP depths = ', SSP%Nz
+      WRITE(msgBuf,'(A,I10)') 'Number of SSP depths = ', SSP%Nz
       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
   
       WRITE(msgBuf,'(A)') 
       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
       WRITE(msgBuf,'(A)') 'Profile ranges (km):'
       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
-      WRITE(fmtStr,'(A,I,A)') '(T11,',SSP%Nr, 'F10.2)'
+      WRITE(fmtStr,'(A,I10,A)') '(T11,',SSP%Nr, 'F10.2)'
       WRITE(msgBuf,fmtStr) SSP%Seg%r( 1:SSP%Nr )
       CALL PRINT_MESSAGE( msgbuf, PRTFile, SQUEEZE_RIGHT, myThid )
       WRITE(msgBuf,'(A)') 

--- a/sandbox/seeSSP.py
+++ b/sandbox/seeSSP.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+import matplotlib.plt as plt
+import cmocean.cm as cm
+
+with open('diags/ssp.0000000009.data', 'rb') as f:
+    array = np.fromfile(f, dtype='>f')
+
+arr = np.reshape(array, (62,62,15), order='F')
+arr = arr[1:61, 1:61, :]
+
+# Plot
+fig=plt.figure(figsize=(12,10), dpi=180 )
+plt.pcolormesh(arr[:,:,0], cmap=cm.speed, \
+        vmin=arr[:,:,0].min(), vmax=arr[:,:,0].max() )
+plt.colorbar()
+plt.savefig('/home/ivana/regionalgcm/img/bc_gyre_ssss_z1_t9_MPI.png',\
+        bbox_inches='tight',transparent=True)


### PR DESCRIPTION
ihop can now produce the standard output with multiple processes using file format similar to MITgcm's STDOUT.<PID>

ihop now handles error messaging using MITgcm's STDERR.<PID>

Checked on intel+mpi, intel, gnu compilations