### PR TITLE
ihop+MPI

### DIFF
--- a/fortran/TEMPLATE_global_mat_sum_mod.F90
+++ b/fortran/TEMPLATE_global_mat_sum_mod.F90
@@ -1,0 +1,271 @@
+#include "CPP_EEOPTIONS.h"
+
+!--  File global_vec_sum.F: Perform a global sum on a tiled-array of vectors.
+!--   Contents
+!--   o GLOBAL_MAT_SUM_R4
+!--   o GLOBAL_MAT_SUM_R8
+!--   o GLOBAL_MAT_SUM_INT
+
+!---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+!BOP
+! ROUTINE: GLOBAL_MAT_SUM_MOD
+! INTERFACE:
+MODULE global_mat_sum_mod
+! <CONTACT EMAIL="ivana@utexas.edu">
+!   Ivana Escobar
+! </CONTACT>
+
+#ifdef   ALLOW_USE_MPI
+    use mpi
+#endif /* ALLOW_USE_MPI */
+!   USES:
+    IMPLICIT NONE
+!   GLOBAL VARIABLES:
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "EESUPPORT.h"
+
+    PRIVATE
+
+!   PUBLIC INTERFACES
+!===============================================================================
+    public global_mat_sum
+!===============================================================================
+    INTERFACE global_mat_sum
+        MODULE PROCEDURE global_mat_sum_r4, global_mat_sum_r8!, &
+            !global_mat_sum_int
+    END INTERFACE global_mat_sum
+
+CONTAINS
+!   !FUCTION: GLOBAL_MAT_SUM_R4
+
+!   !INTERFACE:
+    FUNCTION GLOBAL_MAT_SUM_R4( & 
+        ndim, nval, &
+        sumPhi,     &
+        myThid )
+
+!   !DESCRIPTION:
+!   Sum the matrix over tiles and then sum the result over all MPI
+!   processes. Within a process only one thread (Master) does the sum.
+!   The same thread also does the inter-process sum for example with MPI
+!   and then writes the result into a shared location. All threads wait
+!   until the sum is available.
+!   Warning: Only works if argument array "sumPhi" is shared by all threads.
+
+!   !INPUT/OUTPUT PARAMETERS:
+!   sumPhi   :: input/output array
+!   myThid   :: thread ID
+    INTEGER, INTENT(IN)     :: ndim, nval, myThid
+    Real*4,  INTENT(INOUT)  :: sumPhi(ndim,nSx,nSy)
+!EOP
+
+!   !LOCAL VARIABLES:
+!   mpiRC   :: MPI return code
+    INTEGER :: i, bi,bj
+    Real*4  :: tmp1(nval), tmp2(nval)
+#ifdef   ALLOW_USE_MPI
+    INTEGER mpiRC
+#endif /* ALLOW_USE_MPI */
+
+    _BARRIER
+    _BEGIN_MASTER( myThid )
+
+!   Sum over all tiles
+    DO i = 1,nval
+        tmp1(i) = 0.
+    ENDDO
+    DO bj = 1,nSy
+        DO bi = 1,nSx
+            DO i = 1,nval
+                tmp1(i) = tmp1(i) + sumPhi( i, bi,bj )
+            ENDDO
+        ENDDO
+    ENDDO
+
+!   Invoke MPI if necessary
+    IF ( usingMPI ) THEN
+
+#ifdef ALLOW_USE_MPI
+        CALL MPI_Allreduce(tmp1,tmp2,nval,MPI_REAL, &
+             MPI_SUM,MPI_COMM_MODEL,mpiRC)
+#endif /* ALLOW_USE_MPI */
+
+!     Copy the results to the first location of the input array
+        DO i = 1,nval
+            sumPhi( i, 1,1 ) = tmp2(i)
+        ENDDO
+
+    ELSE
+!   Copy the results to the first location of the input array
+        DO i = 1,nval
+            sumPhi( i, 1,1 ) = tmp1(i)
+        ENDDO
+
+    ENDIF
+
+    _END_MASTER( myThid )
+    _BARRIER
+
+    RETURN
+    END !FUNCTION GLOBAL_MAT_SUM_R4
+
+!---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+!BOP
+!   !FUNCTION: GLOBAL_MAT_SUM_R8
+
+!   !INTERFACE:
+    FUNCTION GLOBAL_MAT_SUM_R8( &
+         ndim, nval, &
+         sumPhi, &
+         myThid )
+
+!   !DESCRIPTION:
+!   Sum the matrix over tiles and then sum the result over all MPI
+!   processes. Within a process only one thread (Master) does the sum.
+!   The same thread also does the inter-process sum for example with MPI
+!   and then writes the result into a shared location. All threads wait
+!   until the sum is available.
+!   Warning: Only works if argument array "sumPhi" is shared by all threads.
+
+!   !INPUT/OUTPUT PARAMETERS:
+!   sumPhi   :: input/output array
+!   myThid   :: thread ID
+    INTEGER, INTENT(IN)     :: ndim, nval, myThid
+    Real*8,  INTENT(INOUT)  :: sumPhi(ndim,nSx,nSy)
+!EOP
+
+!   !LOCAL VARIABLES:
+!   mpiRC   :: MPI return code
+    INTEGER :: i, bi,bj
+    Real*8  :: tmp1(nval), tmp2(nval)
+#ifdef   ALLOW_USE_MPI
+    INTEGER :: mpiRC
+#endif /* ALLOW_USE_MPI */
+
+    _BARRIER
+    _BEGIN_MASTER( myThid )
+
+!   Sum over all tiles
+    DO i = 1,nval
+        tmp1(i) = 0.
+    ENDDO
+    DO bj = 1,nSy
+        DO bi = 1,nSx
+            DO i = 1,nval
+                tmp1(i) = tmp1(i) + sumPhi( i, bi,bj )
+            ENDDO
+        ENDDO
+    ENDDO
+
+!   Invoke MPI if necessary
+    IF ( usingMPI ) THEN
+
+#ifdef ALLOW_USE_MPI
+        CALL MPI_Allreduce(tmp1,tmp2,nval,MPI_DOUBLE_PRECISION, &
+             MPI_SUM,MPI_COMM_MODEL,mpiRC)
+#endif /* ALLOW_USE_MPI */
+
+!   Copy the results to the first location of the input array
+        DO i = 1,nval
+            sumPhi( i, 1,1 ) = tmp2(i)
+        ENDDO
+
+    ELSE
+!   Copy the results to the first location of the input array
+        DO i = 1,nval
+            sumPhi( i, 1,1 ) = tmp1(i)
+        ENDDO
+
+    ENDIF
+
+    _END_MASTER( myThid )
+    _BARRIER
+
+    RETURN
+    END !FUNCTION GLOBAL_MAT_SUM_R8
+
+!---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+!BOP
+!     !ROUTINE: GLOBAL_MAT_SUM_INT
+
+!     !INTERFACE:
+      SUBROUTINE GLOBAL_MAT_SUM_INT( &
+           ndim, nval, &
+           sumPhi, &
+           myThid )
+
+!     !DESCRIPTION:
+!     Sum the vector over tiles and then sum the result over all MPI
+!     processes. Within a process only one thread (Master) does the sum.
+!     The same thread also does the inter-process sum for example with MPI
+!     and then writes the result into a shared location. All threads wait
+!     until the sum is available.
+!     Warning: Only works if argument array "sumPhi" is shared by all threads.
+
+!     !USES:
+      IMPLICIT NONE
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "EESUPPORT.h"
+!#include "GLOBAL_SUM.h"
+
+!     !INPUT/OUTPUT PARAMETERS:
+!     sumPhi   :: input/output array
+!     myThid   :: thread ID
+      INTEGER, INTENT(IN) :: ndim, nval, myThid
+      INTEGER, INTENT(INOUT) :: sumPhi(ndim,nSx,nSy)
+!EOP
+
+!     !LOCAL VARIABLES:
+!     mpiRC    :: MPI return code
+      INTEGER :: i, bi,bj
+      INTEGER :: tmp1(nval), tmp2(nval)
+#ifdef   ALLOW_USE_MPI
+      INTEGER :: mpiRC
+#endif /* ALLOW_USE_MPI */
+
+      _BARRIER
+      _BEGIN_MASTER( myThid )
+
+!     Sum over all tiles
+      DO i = 1,nval
+        tmp1(i) = 0
+      ENDDO
+      DO bj = 1,nSy
+        DO bi = 1,nSx
+          DO i = 1,nval
+            tmp1(i) = tmp1(i) + sumPhi( i, bi,bj )
+          ENDDO
+        ENDDO
+      ENDDO
+
+!     Invoke MPI if necessary
+      IF ( usingMPI ) THEN
+
+#ifdef  ALLOW_USE_MPI
+        CALL MPI_Allreduce(tmp1,tmp2,nval,MPI_INTEGER, &
+             MPI_SUM,MPI_COMM_MODEL,mpiRC)
+#endif /*  ALLOW_USE_MPI */
+
+!     Copy the results to the first location of the input array
+        DO i = 1,nval
+          sumPhi( i, 1,1 ) = tmp2(i)
+        ENDDO
+
+      ELSE
+!     Copy the results to the first location of the input array
+        DO i = 1,nval
+          sumPhi( i, 1,1 ) = tmp1(i)
+        ENDDO
+
+      ENDIF
+
+      _END_MASTER( myThid )
+      _BARRIER
+
+      RETURN
+      END
+
+!---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+END MODULE global_mat_sum_mod

--- a/ihop/bellhop.F90
+++ b/ihop/bellhop.F90
@@ -268,6 +268,12 @@ CONTAINS
   
 #ifdef IHOP_WRITE_OUT
     ! print run time
+    if (numberOfProcs.gt.1) then
+        if(myProcId.ne.(numberOfProcs-1)) then
+            WRITE(msgBuf,'(A,I4,A)') 'Proc ',myProcId, " didn't run ihop"
+            CALL PRINT_MESSAGE(msgBuf, PRTFile, SQUEEZE_RIGHT, myThid)
+        endif
+    endif
     WRITE(msgBuf, '(A)' )
     CALL PRINT_MESSAGE(msgBuf, PRTFile, SQUEEZE_RIGHT, myThid)
     WRITE(msgBuf, '(A,G15.3,A)' ) 'CPU Time = ', Tstop-Tstart, 's'

--- a/ihop/bellhop.F90
+++ b/ihop/bellhop.F90
@@ -258,9 +258,13 @@ CONTAINS
     CALL OpenOutputFiles( IHOP_fileroot )
   
     ! Run Bellhop solver
-    CALL CPU_TIME( Tstart )
-    CALL BellhopCore(myThid)
-    CALL CPU_TIME( Tstop )
+    if (numberOfProcs.gt.1) then
+        if(myProcId.eq.(numberOfProcs-1)) then
+            CALL CPU_TIME( Tstart )
+            CALL BellhopCore(myThid)
+            CALL CPU_TIME( Tstop )
+        endif
+    endif
   
 #ifdef IHOP_WRITE_OUT
     ! print run time

--- a/ihop/mitgcm_input/data.diagnostics
+++ b/ihop/mitgcm_input/data.diagnostics
@@ -2,6 +2,11 @@
   fileName(1)     = 'diags/ssp',
   fields(1:1,1)   = 'ihop_ssp',
   frequency(1)    = 1200.,
+
+  fileName(2)     = 'diags/dynDiag',
+  fields(1:6,2)   = 'THETA   ', 'SALT    ', 'PHIHYD  ',
+                    'UVEL    ', 'VVEL    ', 'WVEL    ',
+  frequency(2)    = 1200.,
  &
 
  &DIAG_STATIS_PARMS

--- a/ihop/readenvihop.F90
+++ b/ihop/readenvihop.F90
@@ -61,6 +61,7 @@ CONTAINS
     CHARACTER (LEN=10) :: PlotType
 
     !   Only do I/O if in the main thread
+    _BARRIER
     _BEGIN_MASTER(myThid)
 
 #ifdef IHOP_WRITE_OUT


### PR DESCRIPTION
Applied a global send receive call, `GLOBAL_VEC_SUM_R8` via a temporary array in S/R ExtractSSP. 

Restricted ihop to only run on a single processor, which leads to PRTFile and STDERR to only have sensical info on the process used, which is `numberOfProcs-1`. 

Can now run on a single processor with MPI enabled on MITgcm, and checked that it works in an intel compiled serial run. 