### PR TITLE
SSP Extrapolation with partial cells

### DIFF
--- a/ihop/bdry_mod.F90
+++ b/ihop/bdry_mod.F90
@@ -229,7 +229,7 @@ CONTAINS
 
   ! **********************************************************************!
 
-   SUBROUTINE ReadBTY( FileRoot, BotBTY, DepthB, myThid )
+SUBROUTINE ReadBTY( FileRoot, BotBTY, DepthB, myThid )
    ! Reads in the bottom bathymetry
 
    !     == Routine Arguments ==
@@ -448,7 +448,7 @@ CONTAINS
    END IF 
 
    RETURN
-   END !SUBROUTINE ReadBTY
+END !SUBROUTINE ReadBTY
 
   ! **********************************************************************!
 

--- a/ihop/bellhop.F90
+++ b/ihop/bellhop.F90
@@ -234,7 +234,7 @@ CONTAINS
        CALL ReadEnvironment( IHOP_fileroot, myThid )
        ! AlTImetry: OPTIONAL, default is no ATIFile
        CALL ReadATI( IHOP_fileroot, Bdry%Top%HS%Opt( 5:5 ), Bdry%Top%HS%Depth, myThid )
-       ! BaThYmetry: OPTIONAL, default is no BTYFile
+       ! BaThYmetry: OPTIONAL, default is BTYFile
        CALL ReadBTY( IHOP_fileroot, Bdry%Bot%HS%Opt( 2:2 ), Bdry%Bot%HS%Depth, myThid )
        ! (top and bottom): OPTIONAL
        CALL ReadReflectionCoefficient( IHOP_fileroot, Bdry%Bot%HS%Opt( 1:1 ), &
@@ -264,6 +264,10 @@ CONTAINS
             CALL BellhopCore(myThid)
             CALL CPU_TIME( Tstop )
         endif
+    else
+        CALL CPU_TIME( Tstart )
+        CALL BellhopCore(myThid)
+        CALL CPU_TIME( Tstop )
     endif
   
 #ifdef IHOP_WRITE_OUT

--- a/ihop/readenvihop.F90
+++ b/ihop/readenvihop.F90
@@ -105,7 +105,7 @@ CONTAINS
     IF ( IHOP_depth.NE.0 ) THEN
         Bdry%Bot%HS%Depth = IHOP_depth
     ELSE
-        Bdry%Bot%HS%Depth = rkSign*rF( Nr+1 )*1.05
+        Bdry%Bot%HS%Depth = rkSign*rF( Nr+1 ) + 5*1500.0/IHOP_freq ! add 5 wavelengths
     END IF
     x = [ 0.0 _d 0, Bdry%Bot%HS%Depth ]   ! tells SSP Depth to read to
 


### PR DESCRIPTION
MITgcm has the option to vary bathymetry using partial cells, set in **data:PARM01** with `hFacMin = 0.05` in my examples. **ihop** cannot understand that no SSP field may just mean you're in bathymetry (inherited from BELLHOP grid definitions). 

So, we extrapolate the sound speed profile (SSP) through bathymetry. This update uses a constant gradient of the sound speed field in the water column.

Tested in gfortran+arm64, ifort+amd64, ifort+amd64+mpi for baroclinic gyre with varying bathymetry. 

[ISSUE-12_partial-cell-extrapolate.pdf](https://github.com/IvanaEscobar/sandbox/files/12807034/ISSUE-12_partial-cell-extrapolate.pdf)
